### PR TITLE
Allow using frame-based layout

### DIFF
--- a/src/foundation/mod.rs
+++ b/src/foundation/mod.rs
@@ -31,15 +31,31 @@ mod class;
 pub use class::load_or_register_class;
 
 mod data;
+
 pub use data::NSData;
 
 mod dictionary;
+
 pub use dictionary::NSDictionary;
 
 mod number;
+
 pub use number::NSNumber;
 
+mod point;
+
+pub use point::NSPoint;
+
+mod rect;
+
+pub use rect::NSRect;
+
+mod size;
+
+pub use size::NSSize;
+
 mod string;
+
 pub use string::NSString;
 
 /// Bool mapping types differ between ARM and x64. There's a number of places that we need to check
@@ -49,10 +65,12 @@ pub fn to_bool(result: BOOL) -> bool {
     match result {
         YES => true,
         NO => false,
-        
+
         //#[cfg(target_arch = "aarch64")]
         #[cfg(not(target_arch = "aarch64"))]
-        _ => { std::unreachable!(); }
+        _ => {
+            std::unreachable!();
+        }
     }
 }
 

--- a/src/foundation/point.rs
+++ b/src/foundation/point.rs
@@ -1,0 +1,30 @@
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+use objc::runtime::Object;
+use objc::{class, msg_send, sel, sel_impl};
+use objc_id::Id;
+
+use crate::core_graphics::base::CGFloat;
+use crate::foundation::{id, to_bool, NSInteger, BOOL, NO, YES};
+use core_graphics::display::CGPoint;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct NSPoint {
+    pub x: CGFloat,
+    pub y: CGFloat,
+}
+
+impl NSPoint {
+    /// Creates a new `NSPoint`.
+    pub fn new(x: CGFloat, y: CGFloat) -> Self {
+        Self { x, y }
+    }
+
+    /// Utility method for checking whether an `NSObject` is an `NSPoint`.
+    pub fn is(obj: id) -> bool {
+        let result: BOOL = unsafe { msg_send![obj, isKindOfClass: class!(NSPoint)] };
+        to_bool(result)
+    }
+}

--- a/src/foundation/rect.rs
+++ b/src/foundation/rect.rs
@@ -1,0 +1,37 @@
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+use objc::runtime::Object;
+use objc::{class, msg_send, sel, sel_impl};
+use objc_id::Id;
+
+use crate::core_graphics::base::CGFloat;
+use crate::foundation::{id, to_bool, NSInteger, NSPoint, NSSize, BOOL, NO, YES};
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct NSRect {
+    pub origin: NSPoint,
+    pub size: NSSize,
+}
+
+impl NSRect {
+    /// Creates a new `NSRect`.
+    pub fn new(x: CGFloat, y: CGFloat, w: CGFloat, h: CGFloat) -> Self {
+        Self {
+            origin: NSPoint::new(x, y),
+            size: NSSize::new(w, h),
+        }
+    }
+
+    /// Utility method for checking whether an `NSObject` is an `NSRect`.
+    pub fn is(obj: id) -> bool {
+        let result: BOOL = unsafe { msg_send![obj, isKindOfClass: class!(NSRect)] };
+        to_bool(result)
+    }
+}
+
+#[link(name = "Foundation", kind = "framework")]
+extern "C" {
+    fn NSInsetRect(rect: NSRect, x: CGFloat, y: CGFloat) -> NSRect;
+}

--- a/src/foundation/size.rs
+++ b/src/foundation/size.rs
@@ -1,0 +1,29 @@
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+use objc::runtime::Object;
+use objc::{class, msg_send, sel, sel_impl};
+use objc_id::Id;
+
+use crate::core_graphics::base::CGFloat;
+use crate::foundation::{id, to_bool, NSInteger, BOOL, NO, YES};
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct NSSize {
+    pub width: CGFloat,
+    pub height: CGFloat,
+}
+
+impl NSSize {
+    /// Creates a new `NSSize`.
+    pub fn new(width: CGFloat, height: CGFloat) -> Self {
+        Self { width, height }
+    }
+
+    /// Utility method for checking whether an `NSObject` is an `NSSize`.
+    pub fn is(obj: id) -> bool {
+        let result: BOOL = unsafe { msg_send![obj, isKindOfClass: class!(NSSize)] };
+        to_bool(result)
+    }
+}


### PR DESCRIPTION
Added `set_frame()` and `set_translates_autoresizing_mask_into_constraints()` to enable using Cacao with applications that use frame-based UI construction as per conversation with Ryan.

Also added `NSPoint`, `NSSize` and `NSRect` types to foundation.