### PR TITLE
Standard macOS event handlers for TextField

### DIFF
--- a/src/input/macos.rs
+++ b/src/input/macos.rs
@@ -11,13 +11,62 @@ use std::sync::Once;
 
 use objc::declare::ClassDecl;
 use objc::runtime::{Class, Object, Sel, BOOL};
-use objc::{class, sel, sel_impl};
+use objc::{class, msg_send, sel, sel_impl};
 use objc_id::Id;
 
-use crate::foundation::{id, YES, NO, NSUInteger};
 use crate::dragdrop::DragInfo;
-use crate::input::{TEXTFIELD_DELEGATE_PTR, TextFieldDelegate};
+use crate::foundation::{id, NSString, NSUInteger, NO, YES};
+use crate::input::{TextFieldDelegate, TEXTFIELD_DELEGATE_PTR};
 use crate::utils::load;
+
+/// Called when editing this text field has ended (e.g. user pressed enter).
+extern "C" fn text_did_end_editing<T: TextFieldDelegate>(this: &mut Object, _: Sel, info: id) {
+    let view = load::<T>(this, TEXTFIELD_DELEGATE_PTR);
+    view.text_did_end_editing({
+        let s = NSString::wrap(unsafe { msg_send![this, stringValue] });
+        s.to_str().to_string()
+    });
+}
+
+extern "C" fn text_did_begin_editing<T: TextFieldDelegate>(this: &mut Object, _: Sel, info: id) {
+    let view = load::<T>(this, TEXTFIELD_DELEGATE_PTR);
+    view.text_did_begin_editing({
+        let s = NSString::wrap(unsafe { msg_send![this, stringValue] });
+        s.to_str().to_string()
+    });
+}
+
+extern "C" fn text_did_change<T: TextFieldDelegate>(this: &mut Object, _: Sel, info: id) {
+    let view = load::<T>(this, TEXTFIELD_DELEGATE_PTR);
+    view.text_did_change({
+        let s = NSString::wrap(unsafe { msg_send![this, stringValue] });
+        s.to_str().to_string()
+    });
+}
+
+extern "C" fn text_should_begin_editing<T: TextFieldDelegate>(
+    this: &mut Object,
+    _: Sel,
+    info: id,
+) -> bool {
+    let view = load::<T>(this, TEXTFIELD_DELEGATE_PTR);
+    view.text_should_begin_editing({
+        let s = NSString::wrap(unsafe { msg_send![this, stringValue] });
+        s.to_str().to_string()
+    })
+}
+
+extern "C" fn text_should_end_editing<T: TextFieldDelegate>(
+    this: &mut Object,
+    _: Sel,
+    info: id,
+) -> bool {
+    let view = load::<T>(this, TEXTFIELD_DELEGATE_PTR);
+    view.text_should_end_editing({
+        let s = NSString::wrap(unsafe { msg_send![this, stringValue] });
+        s.to_str().to_string()
+    })
+}
 
 /// Injects an `NSTextField` subclass. This is used for the default views that don't use delegates - we
 /// have separate classes here since we don't want to waste cycles on methods that will never be
@@ -42,17 +91,37 @@ pub(crate) fn register_view_class_with_delegate<T: TextFieldDelegate>() -> *cons
     static INIT: Once = Once::new();
 
     INIT.call_once(|| unsafe {
-        let superclass = class!(NSView);
+        let superclass = class!(NSTextField);
+        // let superclass = class!(NSView);
         let mut decl = ClassDecl::new("RSTTextInputFieldWithDelegate", superclass).unwrap();
 
         // A pointer to the "view controller" on the Rust side. It's expected that this doesn't
         // move.
-        decl.add_ivar::<usize>(TEXTFIELD_DELEGATE_PTR);        
-       
+        decl.add_ivar::<usize>(TEXTFIELD_DELEGATE_PTR);
+
+        decl.add_method(
+            sel!(textDidEndEditing:),
+            text_did_end_editing::<T> as extern "C" fn(&mut Object, _, _),
+        );
+        decl.add_method(
+            sel!(textDidBeginEditing:),
+            text_did_begin_editing::<T> as extern "C" fn(&mut Object, _, _),
+        );
+        decl.add_method(
+            sel!(textDidChange:),
+            text_did_change::<T> as extern "C" fn(&mut Object, _, _),
+        );
+        decl.add_method(
+            sel!(textShouldBeginEditing:),
+            text_should_begin_editing::<T> as extern "C" fn(&mut Object, Sel, *mut Object) -> bool,
+        );
+        decl.add_method(
+            sel!(textShouldEndEditing:),
+            text_should_end_editing::<T> as extern "C" fn(&mut Object, Sel, *mut Object) -> bool,
+        );
+
         VIEW_CLASS = decl.register();
     });
 
-    unsafe {
-        VIEW_CLASS
-    }
+    unsafe { VIEW_CLASS }
 }

--- a/src/input/traits.rs
+++ b/src/input/traits.rs
@@ -1,4 +1,37 @@
 //! Various traits used for Labels.
 
+use crate::input::TextField;
+
 pub trait TextFieldDelegate {
+    /// Used to cache subclass creations on the Objective-C side.
+    /// You can just set this to be the name of your view type. This
+    /// value *must* be unique per-type.
+    const NAME: &'static str;
+
+    /// You should rarely (read: probably never) need to implement this yourself.
+    /// It simply acts as a getter for the associated `NAME` const on this trait.
+    fn subclass_name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    /// Posts a notification when the text is no longer in edit mode.
+    fn text_did_end_editing(&self, _value: String) {}
+
+    /// Requests permission to begin editing a text object.
+    fn text_should_begin_editing(&self, _value: String) -> bool {
+        true
+    }
+
+    /// Posts a notification to the default notification center that the text is about to go into edit mode.
+    fn text_did_begin_editing(&self, _value: String) {}
+
+    /// Posts a notification when the text changes, and forwards the message to the text field’s cell if it responds.
+    fn text_did_change(&self, _value: String) {}
+
+    /// Performs validation on the text field’s new value.
+    fn text_should_end_editing(&self, _value: String) -> bool {
+        true
+    }
+
+    fn did_load(&mut self, view: TextField) {}
 }


### PR DESCRIPTION
Added 

- text_should_begin_editing()
- text_did_begin_editing()
- text_did_change()
- text_should_end_editing()
- text_did_end_editing() 
event handlers.

For now these only take the value from the TextField and hand it over as a String.

@ryanmcgrath Hope this doesn't create any races/incompatibilities with your central notification center implementation.