### PR TITLE
feat(webview): Add custom protocol (scheme) support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ objc_id = "0.1.1"
 os_info = "3.0.1"
 uuid = { version = "0.8", features = ["v4"], optional = true }
 url = "2.1.1"
+infer = "0.4"
 
 [dev-dependencies]
 eval = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ objc_id = "0.1.1"
 os_info = "3.0.1"
 uuid = { version = "0.8", features = ["v4"], optional = true }
 url = "2.1.1"
-infer = "0.4"
+infer = { version = "0.4", optional = true }
 
 [dev-dependencies]
 eval = "0.4"
@@ -37,7 +37,7 @@ cloudkit = []
 color_fallbacks = []
 quicklook = []
 user-notifications = ["uuid"]
-webview = []
+webview = ["infer"]
 webview-downloading-macos = []
 
 [package.metadata.bundle.example.ios-beta]

--- a/examples/webview_custom_protocol.rs
+++ b/examples/webview_custom_protocol.rs
@@ -1,0 +1,104 @@
+//! This example showcases setting up a basic application and window, setting up some views to
+//! work with autolayout, and some basic ways to handle colors.
+
+use cacao::webview::{WebView, WebViewConfig, WebViewDelegate};
+
+use cacao::macos::{App, AppDelegate};
+use cacao::macos::menu::{Menu, MenuItem};
+use cacao::macos::toolbar::Toolbar;
+use cacao::macos::window::{Window, WindowConfig, WindowDelegate, WindowToolbarStyle};
+
+struct BasicApp {
+    window: Window<AppWindow>
+}
+
+impl AppDelegate for BasicApp {
+    fn did_finish_launching(&self) {
+        App::activate();
+        self.window.show();
+    }
+}
+
+#[derive(Default)]
+pub struct WebViewInstance;
+
+impl WebViewDelegate for WebViewInstance {
+    fn on_custom_protocol_request(&self, path: &str) -> Option<Vec<u8>> {
+        let requested_asset_path = path.replace("cacao://", "");
+
+        let index_html = r#"
+        <!DOCTYPE html>
+        <html lang="en">
+            <head>
+            <meta charset="UTF-8" />
+            <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            </head>
+            <body>
+            <h1>Welcome 🍫</h1>
+            <a href="/hello.html">Link</a>
+            </body>
+        </html>"#; 
+        
+        let link_html = r#"
+        <!DOCTYPE html>
+        <html lang="en">
+            <head>
+            <meta charset="UTF-8" />
+            <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            </head>
+            <body>
+            <h1>Hello!</h1>
+            <a href="/index.html">Back home</a>
+            </body>
+        </html>"#; 
+
+        return match requested_asset_path.as_str() {
+            "/hello.html" => Some(link_html.as_bytes().into()),
+            _ => Some(index_html.as_bytes().into()),
+        }
+    }
+}
+
+struct AppWindow {
+    content: WebView<WebViewInstance>
+}
+
+impl AppWindow {
+    pub fn new() -> Self {
+        let mut webview_config = WebViewConfig::default();
+
+        // register the protocol in the webview
+        webview_config.add_custom_protocol("cacao");
+
+        AppWindow {
+            content: WebView::with(webview_config, WebViewInstance::default())
+        }
+    }
+
+    pub fn load_url(&self, url: &str) {
+        self.content.load_url(url);
+    }
+}
+
+impl WindowDelegate for AppWindow {
+    const NAME: &'static str = "WindowDelegate";
+
+    fn did_load(&mut self, window: Window) {
+        window.set_title("Browser Example");
+        window.set_autosave_name("CacaoBrowserExample");
+        window.set_minimum_content_size(400., 400.);
+
+        window.set_content_view(&self.content);
+
+        // load custom protocol
+        self.load_url("cacao://");
+    }
+}
+
+fn main() {
+    App::new("com.test.window", BasicApp {
+        window: Window::with(WindowConfig::default(), AppWindow::new())
+    }).run();
+}

--- a/src/webview/config.rs
+++ b/src/webview/config.rs
@@ -13,7 +13,8 @@ use crate::webview::enums::InjectAt;
 #[derive(Debug)]
 pub struct WebViewConfig {
     pub objc: Id<Object>,
-    pub handlers: Vec<String>
+    pub handlers: Vec<String>,
+    pub protocols: Vec<String>
 }
 
 impl Default for WebViewConfig {
@@ -26,7 +27,8 @@ impl Default for WebViewConfig {
 
         WebViewConfig {
             objc: config,
-            handlers: vec![]
+            handlers: vec![],
+            protocols: vec![]
         }
     }
 }
@@ -53,6 +55,12 @@ impl WebViewConfig {
             let content_controller: id = msg_send![&*self.objc, userContentController];
             let _: () = msg_send![content_controller, addUserScript:user_script];
         }
+    }
+
+    /// Register the given protocol to the underlying `WKWebView`.
+    /// Example; protocol_name: `demo` will allow request to `demo://`
+    pub fn add_custom_protocol(&mut self, protocol_name: &str) {
+        self.protocols.push(protocol_name.to_string());
     }
 
     /// Enables access to the underlying inspector view for `WKWebView`.

--- a/src/webview/mimetype.rs
+++ b/src/webview/mimetype.rs
@@ -1,0 +1,73 @@
+use std::fmt;
+
+const MIMETYPE_PLAIN: &str = "text/plain";
+
+/// [Web Compatible MimeTypes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#important_mime_types_for_web_developers)
+pub enum MimeType {
+   CSS,
+   CSV,
+   HTML,
+   ICO,
+   JS,
+   JSON,
+   JSONLD,
+   OCTETSTREAM,
+   RTF,
+   SVG,
+}
+
+impl std::fmt::Display for MimeType {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    let mime = match self {
+      MimeType::CSS => "text/css",
+      MimeType::CSV => "text/csv",
+      MimeType::HTML => "text/html",
+      MimeType::ICO => "image/vnd.microsoft.icon",
+      MimeType::JS => "text/javascript",
+      MimeType::JSON => "application/json",
+      MimeType::JSONLD => "application/ld+json",
+      MimeType::OCTETSTREAM => "application/octet-stream",
+      MimeType::RTF => "application/rtf",
+      MimeType::SVG => "image/svg+xml",
+    };
+    write!(f, "{}", mime)
+  }
+}
+
+impl MimeType {
+  /// parse a URI suffix to convert text/plain mimeType to their actual web compatible mimeType.
+  pub fn parse_from_uri(uri: &str) -> MimeType {
+    let suffix = uri.split('.').last();
+    match suffix {
+      Some("bin") => Self::OCTETSTREAM,
+      Some("css") => Self::CSS,
+      Some("csv") => Self::CSV,
+      Some("html") => Self::HTML,
+      Some("ico") => Self::ICO,
+      Some("js") => Self::JS,
+      Some("json") => Self::JSON,
+      Some("jsonld") => Self::JSONLD,
+      Some("rtf") => Self::RTF,
+      Some("svg") => Self::SVG,
+      // Assume HTML when a TLD is found for eg. `protocol:://example.com`
+      Some(_) => Self::HTML,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+      // using octet stream according to this:
+      None => Self::OCTETSTREAM,
+    }
+  }
+
+  /// infer mimetype from content (or) URI if needed.
+  pub fn parse(content: &[u8], uri: &str) -> String {
+    let mime = match infer::get(&content) {
+      Some(info) => info.mime_type(),
+      None => MIMETYPE_PLAIN,
+    };
+
+    if mime == MIMETYPE_PLAIN {
+      return Self::parse_from_uri(uri).to_string();
+    }
+
+    mime.to_string()
+  }
+}

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -38,6 +38,7 @@ pub(crate) mod class;
 use class::{register_webview_class, register_webview_delegate_class};
 //pub(crate) mod process_pool;
 
+mod mimetype;
 mod traits;
 pub use traits::WebViewDelegate;
 
@@ -50,6 +51,7 @@ fn allocate_webview(
     unsafe {
         // Not a fan of this, but we own it anyway, so... meh.
         let handlers = std::mem::take(&mut config.handlers);
+        let protocols = std::mem::take(&mut config.protocols);
         let configuration = config.into_inner();
         
         if let Some(delegate) = &objc_delegate {
@@ -65,6 +67,11 @@ fn allocate_webview(
             for handler in handlers {
                 let name = NSString::new(&handler);
                 let _: () = msg_send![content_controller, addScriptMessageHandler:*delegate name:&*name];
+            }
+
+            for protocol in protocols {
+                let name = NSString::new(&protocol);
+                let _: () = msg_send![configuration, setURLSchemeHandler:*delegate forURLScheme:&*name];
             }
         }
 

--- a/src/webview/traits.rs
+++ b/src/webview/traits.rs
@@ -33,6 +33,11 @@ pub trait WebViewDelegate {
     /// Note that at the moment, you really should handle bridging JSON/stringification yourself.
     fn on_message(&self, _name: &str, _body: &str) {}
 
+    /// Called when a custom protocol URI is requested.
+    fn on_custom_protocol_request(&self, _uri: &str) -> Option<Vec<u8>> {
+        None
+    }
+
     /// Given a callback handler, you can decide what policy should be taken for a given browser
     /// action. By default, this is `NavigationPolicy::Allow`.
     fn policy_for_navigation_action<F: Fn(NavigationPolicy)>(&self, _action: NavigationAction, handler: F) {


### PR DESCRIPTION
This is a basic implementation of the custom protocol (scheme)

To make it clear, I added an example and can be run with:

```
cargo run --example webview_custom_protocol --features webview
```

https://user-images.githubusercontent.com/22237916/116000656-26030200-a5bf-11eb-819d-8186c3b2e1be.mov
