### PR TITLE
Change calling function, wrap -> retain in NSString

### DIFF
--- a/src/user_notifications/mod.rs
+++ b/src/user_notifications/mod.rs
@@ -26,7 +26,7 @@ impl NotificationCenter {
         unsafe {
             // @TODO: Revisit.
             let block = ConcreteBlock::new(|_: id, error: id| {
-                let localized_description = NSString::wrap(msg_send![error, localizedDescription]); 
+                let localized_description = NSString::retain(msg_send![error, localizedDescription]); 
                 let e = localized_description.to_str();
                 if e != "" {
                     println!("{:?}", e);


### PR DESCRIPTION
Hello, while I'm testing whether desktop notification works if I use `cacao` (testing in my [cacao_playground](https://github.com/24seconds/cacao_playground) repo), I found `user_notifications/mod.rs` has called deprecated function of `NSString`.

I looked up the file history and found that `NSString` once had a function `wrap` but it seems to be replaced into [reatin](https://github.com/ryanmcgrath/cacao/blob/87eda8f94af8c15eef5e2e3386764407f21d53eb/src/foundation/string.rs#L59) function.  

So I made a simple change :D