### PR TITLE
Replace `core-foundation` and `core-graphics`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 bitmask-enum = "2.2.1"
 objc = { version = "=0.3.0-beta.2", package = "objc2" }
 block = { version = "=0.2.0-alpha.6", package = "block2" }
-# Temporary: Patched versions that implement `Encode` for common types
-# Branch: `objc2`
-core-foundation = { git = "https://github.com/madsmtm/core-foundation-rs.git", rev = "7d593d016175755e492a92ef89edca68ac3bd5cd" }
 dispatch = "0.2.0"
 infer = { version = "0.15", optional = true }
 lazy_static = "1.4.0"
@@ -39,7 +36,7 @@ core-graphics = "0.23"
 foreign-types = "0.5"
 
 [features]
-appkit = ["core-foundation/mac_os_10_8_features"]
+appkit = []
 uikit = []
 autolayout = []
 default = ["appkit", "autolayout"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ block = { version = "=0.2.0-alpha.6", package = "block2" }
 # Temporary: Patched versions that implement `Encode` for common types
 # Branch: `objc2`
 core-foundation = { git = "https://github.com/madsmtm/core-foundation-rs.git", rev = "7d593d016175755e492a92ef89edca68ac3bd5cd" }
-core-graphics = { git = "https://github.com/madsmtm/core-foundation-rs.git", rev = "7d593d016175755e492a92ef89edca68ac3bd5cd" }
 dispatch = "0.2.0"
 infer = { version = "0.15", optional = true }
 lazy_static = "1.4.0"
@@ -36,6 +35,8 @@ uuid = { version = "1.1", features = ["v4"], optional = true }
 
 [dev-dependencies]
 eval = "0.4"
+core-graphics = "0.23"
+foreign-types = "0.5"
 
 [features]
 appkit = ["core-foundation/mac_os_10_8_features"]

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The following are a list of [Cargo features][cargo-features] that can be enabled
 
 ## General Notes
 **Why not extend the existing cocoa-rs crate?**
-A good question. At the end of the day, that crate (I believe, and someone can correct me if I'm wrong) is somewhat tied to Servo, and I wanted to experiment with what the best approach for representing the Cocoa UI model in Rust was. This crate doesn't ignore their work entirely, either - `core_foundation` is used internally and re-exported for general use.
+A good question. At the end of the day, that crate (I believe, and someone can correct me if I'm wrong) is somewhat tied to Servo, and I wanted to experiment with what the best approach for representing the Cocoa UI model in Rust was.
 
 **Why should I write in Rust, rather than X language?**  
 In _my_ case, I want to be able to write native applications for my devices (and the platform I like to build products for) without being locked in to writing in Apple-specific languages... and without writing in C/C++ or JavaScript (note: the _toolchain_, not the language - ES6/Typescript are fine). I want to do this because I'm tired of hitting a mountain of work when I want to port my applications to other ecosystems. I think that Rust offers a (growing, but significant) viable model for sharing code across platforms and ecosystems without sacrificing performance.

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ The following are a list of [Cargo features][cargo-features] that can be enabled
 [cargo-features]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-features-section
 
 ## General Notes
-**Why not extend the existing cocoa-rs crate?**  
-A good question. At the end of the day, that crate (I believe, and someone can correct me if I'm wrong) is somewhat tied to Servo, and I wanted to experiment with what the best approach for representing the Cocoa UI model in Rust was. This crate doesn't ignore their work entirely, either - `core_foundation` and `core_graphics` are used internally and re-exported for general use.
+**Why not extend the existing cocoa-rs crate?**
+A good question. At the end of the day, that crate (I believe, and someone can correct me if I'm wrong) is somewhat tied to Servo, and I wanted to experiment with what the best approach for representing the Cocoa UI model in Rust was. This crate doesn't ignore their work entirely, either - `core_foundation` is used internally and re-exported for general use.
 
 **Why should I write in Rust, rather than X language?**  
 In _my_ case, I want to be able to write native applications for my devices (and the platform I like to build products for) without being locked in to writing in Apple-specific languages... and without writing in C/C++ or JavaScript (note: the _toolchain_, not the language - ES6/Typescript are fine). I want to do this because I'm tired of hitting a mountain of work when I want to port my applications to other ecosystems. I think that Rust offers a (growing, but significant) viable model for sharing code across platforms and ecosystems without sacrificing performance.

--- a/examples/custom_image_drawing.rs
+++ b/examples/custom_image_drawing.rs
@@ -1,6 +1,9 @@
 //! This example showcases how to do custom drawing on an ImageView
 //! with CoreGraphics. Feel free to modify it and play around!
 
+use core_graphics::context::CGContextRef;
+use foreign_types::ForeignTypeRef;
+
 use cacao::appkit::menu::{Menu, MenuItem};
 use cacao::appkit::window::Window;
 use cacao::appkit::{App, AppDelegate};
@@ -30,7 +33,12 @@ impl Default for BasicApp {
             window: Window::default(),
             content_view: View::new(),
             image_view: ImageView::new(),
-            image: Image::draw(config, |_cg_rect, context| {
+            image: Image::draw(config, |resized_frame, source, context| {
+                let context = unsafe { CGContextRef::from_ptr(context.cast()) };
+
+                context.translate(resized_frame.top, resized_frame.left);
+                context.scale(resized_frame.width / source.0, resized_frame.height / source.1);
+
                 context.move_to_point(11.25, 8.19);
                 context.add_line_to_point(11.25, 5.);
                 context.add_line_to_point(6.56, 5.);

--- a/src/appkit/event/mod.rs
+++ b/src/appkit/event/mod.rs
@@ -1,12 +1,13 @@
 use bitmask_enum::bitmask;
 use block::ConcreteBlock;
 
+use objc::foundation::NSPoint;
 use objc::rc::{Id, Owned};
 use objc::runtime::Object;
 use objc::{class, msg_send, msg_send_id, sel};
 
 use crate::events::EventType;
-use crate::foundation::{id, nil, NSInteger, NSPoint, NSString};
+use crate::foundation::{id, nil, NSInteger, NSString};
 
 /// An EventMask describes the type of event.
 #[bitmask(u64)]

--- a/src/appkit/segmentedcontrol.rs
+++ b/src/appkit/segmentedcontrol.rs
@@ -239,7 +239,7 @@ impl SegmentedControl {
         #[cfg(feature = "appkit")]
         self.objc.with_mut(move |obj| unsafe {
             let text: id = msg_send![obj, attributedTitle];
-            let len: isize = msg_send![text, length];
+            let len: usize = msg_send![text, length];
 
             let mut attr_str = AttributedString::wrap(text);
             attr_str.set_text_color(color.as_ref(), 0..len);

--- a/src/appkit/toolbar/item.rs
+++ b/src/appkit/toolbar/item.rs
@@ -3,9 +3,9 @@
 //!
 //! UNFORTUNATELY, this is a very old and janky API. So... yeah.
 
-use core_graphics::geometry::CGSize;
 use std::fmt;
 
+use objc::foundation::NSSize;
 use objc::rc::{Id, Owned, Shared};
 use objc::runtime::Object;
 use objc::{class, msg_send, msg_send_id, sel};
@@ -89,7 +89,7 @@ impl ToolbarItem {
     /// Sets the minimum size for this button.
     pub fn set_min_size(&mut self, width: f64, height: f64) {
         unsafe {
-            let size = CGSize::new(width.into(), height.into());
+            let size = NSSize::new(width.into(), height.into());
             let _: () = msg_send![&*self.objc, setMinSize: size];
         }
     }
@@ -97,7 +97,7 @@ impl ToolbarItem {
     /// Sets the maximum size for this button.
     pub fn set_max_size(&mut self, width: f64, height: f64) {
         unsafe {
-            let size = CGSize::new(width.into(), height.into());
+            let size = NSSize::new(width.into(), height.into());
             let _: () = msg_send![&*self.objc, setMaxSize: size];
         }
     }

--- a/src/appkit/window/class.rs
+++ b/src/appkit/window/class.rs
@@ -3,15 +3,14 @@
 
 use std::sync::Once;
 
-use core_graphics::base::CGFloat;
-
 use objc::declare::ClassDecl;
+use objc::foundation::{CGFloat, NSSize};
 use objc::runtime::{Bool, Class, Object, Sel};
 use objc::{class, sel};
 
 use crate::appkit::window::{WindowDelegate, WINDOW_DELEGATE_PTR};
 use crate::foundation::{id, load_or_register_class, NSUInteger};
-use crate::utils::{load, CGSize};
+use crate::utils::load;
 
 /// Called when an `NSWindowDelegate` receives a `windowWillClose:` event.
 /// Good place to clean up memory and what not.
@@ -53,14 +52,11 @@ extern "C" fn did_change_screen_profile<T: WindowDelegate>(this: &Object, _: Sel
 }
 
 /// Called when an `NSWindowDelegate` receives a `windowDidChangeScreen:` event.
-extern "C" fn will_resize<T: WindowDelegate>(this: &Object, _: Sel, _: id, size: CGSize) -> CGSize {
+extern "C" fn will_resize<T: WindowDelegate>(this: &Object, _: Sel, _: id, size: NSSize) -> NSSize {
     let window = load::<T>(this, WINDOW_DELEGATE_PTR);
-    let s = window.will_resize(size.width as f64, size.height as f64);
+    let s = window.will_resize(size.width() as f64, size.height() as f64);
 
-    CGSize {
-        width: s.0 as CGFloat,
-        height: s.1 as CGFloat
-    }
+    NSSize::new(s.0 as CGFloat, s.1 as CGFloat)
 }
 
 /// Called when an `NSWindowDelegate` receives a `windowDidChangeScreen:` event.
@@ -112,15 +108,12 @@ extern "C" fn did_enter_full_screen<T: WindowDelegate>(this: &Object, _: Sel, _:
 }
 
 /// Called when an `NSWindowDelegate` receives a `windowDidChangeScreenProfile:` event.
-extern "C" fn content_size_for_full_screen<T: WindowDelegate>(this: &Object, _: Sel, _: id, size: CGSize) -> CGSize {
+extern "C" fn content_size_for_full_screen<T: WindowDelegate>(this: &Object, _: Sel, _: id, size: NSSize) -> NSSize {
     let window = load::<T>(this, WINDOW_DELEGATE_PTR);
 
-    let (width, height) = window.content_size_for_full_screen(size.width as f64, size.height as f64);
+    let (width, height) = window.content_size_for_full_screen(size.width() as f64, size.height() as f64);
 
-    CGSize {
-        width: width as CGFloat,
-        height: height as CGFloat
-    }
+    NSSize::new(width as CGFloat, height as CGFloat)
 }
 
 /// Called when an `NSWindowDelegate` receives a `windowDidChangeScreenProfile:` event.

--- a/src/appkit/window/mod.rs
+++ b/src/appkit/window/mod.rs
@@ -10,9 +10,7 @@
 
 use block::ConcreteBlock;
 
-use core_graphics::base::CGFloat;
-use core_graphics::geometry::{CGRect, CGSize};
-
+use objc::foundation::{CGFloat, NSRect, NSSize};
 use objc::rc::{Id, Owned, Shared};
 use objc::runtime::Object;
 use objc::{class, msg_send, msg_send_id, sel};
@@ -75,7 +73,7 @@ impl Window {
             // Other types of backing (Retained/NonRetained) are archaic, dating back to the
             // NeXTSTEP era, and are outright deprecated... so we don't allow setting them.
             let buffered: NSUInteger = 2;
-            let dimensions: CGRect = config.initial_dimensions.into();
+            let dimensions: NSRect = config.initial_dimensions.into();
             let window: Id<_, _> = msg_send_id![
                 msg_send_id![class!(NSWindow), alloc],
                 initWithContentRect: dimensions,
@@ -140,7 +138,7 @@ where
             // Other types of backing (Retained/NonRetained) are archaic, dating back to the
             // NeXTSTEP era, and are outright deprecated... so we don't allow setting them.
             let buffered: NSUInteger = 2;
-            let dimensions: CGRect = config.initial_dimensions.into();
+            let dimensions: NSRect = config.initial_dimensions.into();
             let mut window: Id<Object, Owned> = msg_send_id![
                 msg_send_id![class, alloc],
                 initWithContentRect: dimensions,
@@ -255,7 +253,7 @@ impl<T> Window<T> {
     /// Sets the content size for this window.
     pub fn set_content_size<F: Into<f64>>(&self, width: F, height: F) {
         unsafe {
-            let size = CGSize::new(width.into(), height.into());
+            let size = NSSize::new(width.into(), height.into());
             let _: () = msg_send![&*self.objc, setContentSize: size];
         }
     }
@@ -263,7 +261,7 @@ impl<T> Window<T> {
     /// Sets the minimum size this window can shrink to.
     pub fn set_minimum_content_size<F: Into<f64>>(&self, width: F, height: F) {
         unsafe {
-            let size = CGSize::new(width.into(), height.into());
+            let size = NSSize::new(width.into(), height.into());
             let _: () = msg_send![&*self.objc, setContentMinSize: size];
         }
     }
@@ -271,7 +269,7 @@ impl<T> Window<T> {
     /// Sets the maximum size this window can shrink to.
     pub fn set_maximum_content_size<F: Into<f64>>(&self, width: F, height: F) {
         unsafe {
-            let size = CGSize::new(width.into(), height.into());
+            let size = NSSize::new(width.into(), height.into());
             let _: () = msg_send![&*self.objc, setContentMaxSize: size];
         }
     }
@@ -279,7 +277,7 @@ impl<T> Window<T> {
     /// Sets the minimum size this window can shrink to.
     pub fn set_minimum_size<F: Into<f64>>(&self, width: F, height: F) {
         unsafe {
-            let size = CGSize::new(width.into(), height.into());
+            let size = NSSize::new(width.into(), height.into());
             let _: () = msg_send![&*self.objc, setMinSize: size];
         }
     }

--- a/src/button/mod.rs
+++ b/src/button/mod.rs
@@ -257,7 +257,7 @@ impl Button {
         #[cfg(feature = "appkit")]
         self.objc.with_mut(move |obj| unsafe {
             let text: id = msg_send![obj, attributedTitle];
-            let len: isize = msg_send![text, length];
+            let len: usize = msg_send![text, length];
 
             let mut attr_str = AttributedString::wrap(text);
             attr_str.set_text_color(color.as_ref(), 0..len);

--- a/src/color/appkit_dynamic_color.rs
+++ b/src/color/appkit_dynamic_color.rs
@@ -10,7 +10,7 @@
 //! that enables this functionality, we want to be able to provide this with some level of
 //! backwards compatibility for Mojave, as that's still a supported OS.
 
-use core_graphics::base::CGFloat;
+use objc::foundation::CGFloat;
 use objc::runtime::{Class, Object, Sel};
 use objc::{class, msg_send, sel};
 

--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -16,9 +16,9 @@
 use std::sync::{Arc, RwLock};
 
 use core_foundation::base::TCFType;
-use core_graphics::base::CGFloat;
 use core_graphics::color::CGColor;
 
+use objc::foundation::CGFloat;
 use objc::rc::{Id, Owned};
 use objc::runtime::Object;
 use objc::{class, msg_send, msg_send_id, sel};

--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -4,19 +4,17 @@
 //! we expose some platform-specific methods for creating and working with these.
 //!
 //! We attempt to provide fallbacks for older versions of macOS/iOS, but this is not exhaustive,
-/// as the cross-section of people building for older platforms in Rust is likely very low. If you
-/// need these fallbacks to be better and/or correct, you're welcome to improve and pull-request
-/// this.
-///
-/// The goal here is to make sure that this can't reasonably break on OS's, as `Color` is kind of
-/// an important piece. It's not on the framework to make your app look good, though. To enable
-/// fallbacks, specify the `color_fallbacks` target_os in your `Cargo.toml`.
-///
-/// @TODO: bundle iOS/tvOS support.
+//! as the cross-section of people building for older platforms in Rust is likely very low. If you
+//! need these fallbacks to be better and/or correct, you're welcome to improve and pull-request
+//! this.
+//!
+//! The goal here is to make sure that this can't reasonably break on OS's, as `Color` is kind of
+//! an important piece. It's not on the framework to make your app look good, though. To enable
+//! fallbacks, specify the `color_fallbacks` target_os in your `Cargo.toml`.
+//!
+//! @TODO: bundle iOS/tvOS support.
+use std::ffi::c_void;
 use std::sync::{Arc, RwLock};
-
-use core_foundation::base::TCFType;
-use core_graphics::color::CGColor;
 
 use objc::foundation::CGFloat;
 use objc::rc::{Id, Owned};
@@ -392,10 +390,11 @@ impl Color {
     /// objects. If you're painting in a context that requires dark mode support, make sure
     /// you're not using a cached version of this unless you explicitly want the _same_ color
     /// in every context it's used in.
-    pub fn cg_color(&self) -> CGColor {
+    pub fn cg_color(&self) -> *mut c_void {
+        // TODO: Better return type
         unsafe {
             let objc: id = self.into();
-            CGColor::wrap_under_get_rule(msg_send![objc, CGColor])
+            msg_send![objc, CGColor]
         }
     }
 }

--- a/src/foundation/mod.rs
+++ b/src/foundation/mod.rs
@@ -86,5 +86,3 @@ pub type NSInteger = libc::c_long;
 /// Platform-specific.
 #[cfg(target_pointer_width = "64")]
 pub type NSUInteger = libc::c_ulong;
-
-pub type NSPoint = core_graphics::geometry::CGPoint;

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,6 +1,6 @@
 //! Wrapper methods for various geometry types (rects, sizes, ec).
 
-use core_graphics::geometry::{CGPoint, CGRect, CGSize};
+use objc::foundation::{NSPoint, NSRect, NSSize};
 
 /// A struct that represents a box - top, left, width and height. You might use this for, say,
 /// setting the initial frame of a view.
@@ -49,19 +49,20 @@ pub enum Edge {
     MaxX = 2,
     MaxY = 3
 }
-impl From<Rect> for CGRect {
-    fn from(rect: Rect) -> CGRect {
-        CGRect::new(&CGPoint::new(rect.left, rect.top), &CGSize::new(rect.width, rect.height))
+
+impl From<Rect> for NSRect {
+    fn from(rect: Rect) -> NSRect {
+        NSRect::new(NSPoint::new(rect.left, rect.top), NSSize::new(rect.width, rect.height))
     }
 }
 
-impl From<CGRect> for Rect {
-    fn from(rect: CGRect) -> Rect {
+impl From<NSRect> for Rect {
+    fn from(rect: NSRect) -> Rect {
         Rect {
             top: rect.origin.y as f64,
             left: rect.origin.x as f64,
-            width: rect.size.width as f64,
-            height: rect.size.height as f64
+            width: rect.size.width() as f64,
+            height: rect.size.height() as f64
         }
     }
 }

--- a/src/image/graphics_context.rs
+++ b/src/image/graphics_context.rs
@@ -1,0 +1,26 @@
+use std::ffi::c_void;
+
+use objc::rc::{Id, Shared};
+use objc::runtime::Object;
+use objc::{class, msg_send, msg_send_id};
+
+#[derive(Debug)]
+pub(crate) struct GraphicsContext(pub Id<Object, Shared>);
+
+impl GraphicsContext {
+    pub(crate) fn current() -> Self {
+        Self(unsafe { msg_send_id![class!(NSGraphicsContext), currentContext] })
+    }
+
+    pub(crate) fn save(&self) {
+        unsafe { msg_send![&self.0, saveGraphicsState] }
+    }
+
+    pub(crate) fn restore(&self) {
+        unsafe { msg_send![&self.0, restoreGraphicsState] }
+    }
+
+    pub(crate) fn cg_context(&self) -> *mut c_void {
+        unsafe { msg_send![&self.0, CGContext] }
+    }
+}

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -1,5 +1,3 @@
-use core_foundation::base::TCFType;
-
 use objc::rc::{Id, Shared};
 use objc::runtime::{Class, Object};
 use objc::{msg_send, msg_send_id, sel};
@@ -25,6 +23,8 @@ mod uikit;
 
 #[cfg(all(feature = "uikit", not(feature = "appkit")))]
 use uikit::register_image_view_class;
+
+mod graphics_context;
 
 mod image;
 pub use image::{DrawConfig, Image, ResizeBehavior};
@@ -151,7 +151,7 @@ impl ImageView {
     /// Call this to set the background color for the backing layer.
     pub fn set_background_color<C: AsRef<Color>>(&self, color: C) {
         self.objc.with_mut(|obj| unsafe {
-            let cg = color.as_ref().cg_color().as_concrete_TypeRef();
+            let cg = color.as_ref().cg_color();
             let layer: id = msg_send![obj, layer];
             let _: () = msg_send![layer, setBackgroundColor: cg];
         });

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -43,8 +43,6 @@
 //!
 //! For more information on Autolayout, view the module or check out the examples folder.
 
-use core_foundation::base::TCFType;
-
 use objc::rc::{Id, Shared};
 use objc::runtime::{Class, Object};
 use objc::{class, msg_send, sel};
@@ -308,7 +306,7 @@ impl<T> TextField<T> {
     /// Call this to set the background color for the backing layer.
     pub fn set_background_color<C: AsRef<Color>>(&self, color: C) {
         self.objc.with_mut(|obj| unsafe {
-            let cg = color.as_ref().cg_color().as_concrete_TypeRef();
+            let cg = color.as_ref().cg_color();
             let layer: id = msg_send![obj, layer];
             let _: () = msg_send![layer, setBackgroundColor: cg];
         });

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -12,8 +12,7 @@
 //! view.layer.set_corner_radius(4.0);
 //! ```
 
-use core_graphics::base::CGFloat;
-
+use objc::foundation::CGFloat;
 use objc::rc::{Id, Shared};
 use objc::runtime::Object;
 use objc::{class, msg_send, msg_send_id, sel};

--- a/src/layout/animator.rs
+++ b/src/layout/animator.rs
@@ -1,5 +1,4 @@
-use core_graphics::base::CGFloat;
-
+use objc::foundation::CGFloat;
 use objc::rc::{Id, Shared};
 use objc::runtime::{Class, Object};
 use objc::{msg_send, msg_send_id, sel};

--- a/src/layout/constraint.rs
+++ b/src/layout/constraint.rs
@@ -2,8 +2,7 @@
 //! escape hatch, if you need it (we use it for things like width and height, which aren't handled
 //! by an axis).
 
-use core_graphics::base::CGFloat;
-
+use objc::foundation::CGFloat;
 use objc::rc::{Id, Shared};
 use objc::runtime::Object;
 use objc::{class, msg_send, sel};

--- a/src/layout/dimension.rs
+++ b/src/layout/dimension.rs
@@ -1,5 +1,4 @@
-use core_graphics::base::CGFloat;
-
+use objc::foundation::CGFloat;
 use objc::rc::{Id, Shared};
 use objc::runtime::Object;
 use objc::{class, msg_send, msg_send_id, sel};

--- a/src/layout/traits.rs
+++ b/src/layout/traits.rs
@@ -1,9 +1,7 @@
 //! Various traits related to controllers opting in to autolayout routines and support for view
 //! heirarchies.
 
-use core_graphics::base::CGFloat;
-use core_graphics::geometry::{CGPoint, CGRect, CGSize};
-
+use objc::foundation::{CGFloat, NSRect};
 use objc::rc::{Id, Shared};
 use objc::runtime::Object;
 use objc::{msg_send, sel};
@@ -53,8 +51,8 @@ pub trait Layout: ObjcAccess {
     /// Note that Cacao, by default, opts into autolayout - you need to call
     /// `set_translates_autoresizing_mask_into_constraints` to enable frame-based layout calls (or
     /// use an appropriate initializer for a given view type).
-    fn set_frame<R: Into<CGRect>>(&self, rect: R) {
-        let frame: CGRect = rect.into();
+    fn set_frame<R: Into<NSRect>>(&self, rect: R) {
+        let frame: NSRect = rect.into();
 
         self.with_backing_obj_mut(move |backing_node| unsafe {
             let _: () = msg_send![backing_node, setFrame: frame];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,6 @@
 //!
 //! [cargo-features]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-features-section
 
-pub use core_foundation;
 pub use lazy_static;
 pub use objc;
 pub use url;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@
 //! [cargo-features]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-features-section
 
 pub use core_foundation;
-pub use core_graphics;
 pub use lazy_static;
 pub use objc;
 pub use url;

--- a/src/listview/appkit.rs
+++ b/src/listview/appkit.rs
@@ -30,11 +30,11 @@ extern "C" fn view_for_column<T: ListViewDelegate>(
     _table_column: id,
     item: NSInteger
 ) -> id {
-    /*use core_graphics::geometry::CGRect;
+    /*use objc::foundation::NSRect;
     unsafe {
         //let superview: id = msg_send![table_view, superview];
-        let frame: CGRect = msg_send![table_view, frame];
-        let _: () = msg_send![table_column, setWidth:frame.size.width];
+        let frame: NSRect = msg_send![table_view, frame];
+        let _: () = msg_send![table_column, setWidth:frame.size.width()];
     }*/
 
     let view = load::<T>(this, LISTVIEW_DELEGATE_PTR);

--- a/src/listview/mod.rs
+++ b/src/listview/mod.rs
@@ -44,9 +44,7 @@
 
 use std::collections::HashMap;
 
-use core_foundation::base::TCFType;
-
-use objc::foundation::{CGFloat, NSSize};
+use objc::foundation::CGFloat;
 use objc::rc::{Id, Owned, Shared};
 use objc::runtime::{Class, Object};
 use objc::{class, msg_send, msg_send_id, sel};
@@ -441,7 +439,7 @@ impl<T> ListView<T> {
     pub fn set_background_color<C: AsRef<Color>>(&self, color: C) {
         // @TODO: This is wrong.
         self.objc.with_mut(|obj| unsafe {
-            let color = color.as_ref().cg_color().as_concrete_TypeRef();
+            let color = color.as_ref().cg_color();
             let layer: id = msg_send![obj, layer];
             let _: () = msg_send![layer, setBackgroundColor: color];
         });

--- a/src/listview/mod.rs
+++ b/src/listview/mod.rs
@@ -46,7 +46,7 @@ use std::collections::HashMap;
 
 use core_foundation::base::TCFType;
 
-use core_graphics::base::CGFloat;
+use objc::foundation::{CGFloat, NSSize};
 use objc::rc::{Id, Owned, Shared};
 use objc::runtime::{Class, Object};
 use objc::{class, msg_send, msg_send_id, sel};
@@ -61,7 +61,7 @@ use crate::layout::{LayoutAnchorDimension, LayoutAnchorX, LayoutAnchorY};
 use crate::objc_access::ObjcAccess;
 use crate::scrollview::ScrollView;
 use crate::utils::properties::{ObjcProperty, PropertyNullable};
-use crate::utils::{os, CGSize, CellFactory};
+use crate::utils::{os, CellFactory};
 use crate::view::{ViewAnimatorProxy, ViewDelegate};
 
 #[cfg(feature = "appkit")]
@@ -117,7 +117,7 @@ fn common_init(class: &Class) -> id {
             let _: () = msg_send![tableview, setWantsLayer: YES];
             let _: () = msg_send![tableview, setUsesAutomaticRowHeights: YES];
             let _: () = msg_send![tableview, setFloatsGroupRows: YES];
-            //let _: () = msg_send![tableview, setIntercellSpacing:CGSize::new(0., 0.)];
+            //let _: () = msg_send![tableview, setIntercellSpacing: NSSize::new(0., 0.)];
             let _: () = msg_send![tableview, setColumnAutoresizingStyle:1];
             //msg_send![tableview, setSelectionHighlightStyle:-1];
             //let _: () = msg_send![tableview, setAllowsMultipleSelection:NO];

--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -15,8 +15,7 @@
 //! my_view.add_subview(&indicator);
 //! ```
 
-use core_graphics::base::CGFloat;
-
+use objc::foundation::CGFloat;
 use objc::rc::{Id, Shared};
 use objc::runtime::{Class, Object};
 use objc::{class, msg_send, sel};

--- a/src/quicklook/config.rs
+++ b/src/quicklook/config.rs
@@ -1,12 +1,11 @@
 use std::path::Path;
 
-use core_graphics::base::CGFloat;
+use objc::foundation::{CGFloat, NSSize};
 use objc::rc::{Id, Shared};
 use objc::runtime::Object;
 use objc::{class, msg_send, sel};
 
 use crate::foundation::{id, NSString, NSUInteger, YES};
-use crate::utils::CGSize;
 
 /// Describes the quality of the thumbnail you expect back from the
 /// generator service.
@@ -107,7 +106,7 @@ impl ThumbnailConfig {
         }
 
         unsafe {
-            let size = CGSize::new(self.size.0, self.size.1);
+            let size = NSSize::new(self.size.0, self.size.1);
             // @TODO: Check nil here, or other bad conversion
             let from_url: id = msg_send![class!(NSURL), fileURLWithPath:&*file];
 

--- a/src/scrollview/mod.rs
+++ b/src/scrollview/mod.rs
@@ -42,8 +42,6 @@
 //!
 //! For more information on Autolayout, view the module or check out the examples folder.
 
-use core_foundation::base::TCFType;
-
 use objc::rc::{Id, Shared};
 use objc::runtime::{Class, Object};
 use objc::{msg_send, sel};
@@ -298,7 +296,7 @@ impl<T> ScrollView<T> {
     pub fn set_background_color<C: AsRef<Color>>(&self, color: C) {
         // @TODO: This is wrong.
         self.objc.with_mut(|obj| unsafe {
-            let color = color.as_ref().cg_color().as_concrete_TypeRef();
+            let color = color.as_ref().cg_color();
             let layer: id = msg_send![obj, layer];
             let _: () = msg_send![layer, setBackgroundColor: color];
         });

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -1,6 +1,6 @@
 //! Implements a Select-style dropdown. By default this uses NSPopupSelect on macOS.
 
-use core_graphics::geometry::CGRect;
+use objc::foundation::NSRect;
 use objc::rc::{Id, Shared};
 use objc::runtime::{Class, Object};
 use objc::{msg_send, msg_send_id, sel};
@@ -85,7 +85,7 @@ impl Select {
     /// Creates a new `Select` instance, configures it appropriately,
     /// and retains the necessary Objective-C runtime pointer.
     pub fn new() -> Self {
-        let zero: CGRect = Rect::zero().into();
+        let zero: NSRect = Rect::zero().into();
 
         let view: id = unsafe {
             let alloc: id = msg_send![register_class(), alloc];

--- a/src/text/attributed_string.rs
+++ b/src/text/attributed_string.rs
@@ -3,13 +3,13 @@ use std::ops::{Deref, DerefMut, Range};
 use std::os::raw::c_char;
 use std::{fmt, slice, str};
 
+use objc::foundation::NSRange;
 use objc::rc::{Id, Owned};
 use objc::runtime::Object;
 use objc::{class, msg_send, msg_send_id, sel};
 
 use crate::color::Color;
-use crate::foundation::{id, to_bool, NSString, BOOL, NO, YES};
-use crate::utils::CFRange;
+use crate::foundation::{id, NSString};
 
 use super::Font;
 
@@ -43,9 +43,9 @@ impl AttributedString {
     }
 
     /// Sets the text (foreground) color for the specified range.
-    pub fn set_text_color<C: AsRef<Color>>(&mut self, color: C, range: Range<isize>) {
+    pub fn set_text_color<C: AsRef<Color>>(&mut self, color: C, range: Range<usize>) {
         let color: id = color.as_ref().into();
-        let range = CFRange::init(range.start, range.end);
+        let range = NSRange::from(range);
 
         unsafe {
             let _: () = msg_send![
@@ -58,8 +58,8 @@ impl AttributedString {
     }
 
     /// Set the font for the specified range.
-    pub fn set_font(&mut self, font: Font, range: Range<isize>) {
-        let range = CFRange::init(range.start, range.end);
+    pub fn set_font(&mut self, font: Font, range: Range<usize>) {
+        let range = NSRange::from(range);
 
         unsafe {
             let _: () = msg_send![

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -2,8 +2,7 @@
 
 use std::ops::Deref;
 
-use core_graphics::base::CGFloat;
-
+use objc::foundation::CGFloat;
 use objc::rc::{Id, Shared};
 use objc::runtime::{Class, Object};
 use objc::{class, msg_send, msg_send_id, sel};

--- a/src/text/label/mod.rs
+++ b/src/text/label/mod.rs
@@ -43,8 +43,6 @@
 //!
 //! For more information on Autolayout, view the module or check out the examples folder.
 
-use core_foundation::base::TCFType;
-
 use objc::rc::{Id, Shared};
 use objc::runtime::{Class, Object};
 use objc::{msg_send, msg_send_id, sel};
@@ -326,7 +324,7 @@ impl<T> Label<T> {
         // @TODO: This is wrong.
         // Needs to set ivar and such, akin to View.
         self.objc.with_mut(|obj| unsafe {
-            let color = color.as_ref().cg_color().as_concrete_TypeRef();
+            let color = color.as_ref().cg_color();
             let layer: id = msg_send![obj, layer];
             let _: () = msg_send![layer, setBackgroundColor: color];
         });

--- a/src/uikit/scene/mod.rs
+++ b/src/uikit/scene/mod.rs
@@ -3,8 +3,7 @@
 //! This is required for things like having multiple instances of your app in the app switcher on
 //! iPad. In general, you probably won't need to tweak this though.
 
-use core_graphics::geometry::CGRect;
-
+use objc::foundation::NSRect;
 use objc::rc::{Id, Owned};
 use objc::runtime::Object;
 use objc::{class, msg_send, sel};
@@ -43,7 +42,7 @@ impl Scene {
     pub fn get_bounds(&self) -> Rect {
         unsafe {
             let coordinate_space: id = msg_send![&*self.0, coordinateSpace];
-            let rect: CGRect = msg_send![coordinate_space, bounds];
+            let rect: NSRect = msg_send![coordinate_space, bounds];
             rect
         }
         .into()

--- a/src/uikit/window/mod.rs
+++ b/src/uikit/window/mod.rs
@@ -1,5 +1,4 @@
-use core_graphics::geometry::CGRect;
-
+use objc::foundation::NSRect;
 use objc::rc::{Id, Owned};
 use objc::runtime::Object;
 use objc::{class, msg_send, msg_send_id, sel};
@@ -15,7 +14,7 @@ pub struct Window(pub Id<Object, Owned>);
 impl Window {
     pub fn new(frame: Rect) -> Self {
         Window(unsafe {
-            let rect: CGRect = frame.into();
+            let rect: NSRect = frame.into();
             let alloc = msg_send_id![class!(UIWindow), alloc];
             msg_send_id![alloc, initWithFrame: rect]
         })

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,12 +3,10 @@
 //! they go away one day.
 
 use core_foundation::base::CFIndex;
-use core_graphics::base::CGFloat;
-
-use objc::{class, msg_send, sel};
 
 use objc::rc::{Id, Shared};
 use objc::runtime::Object;
+use objc::{class, msg_send, sel};
 use objc::{Encode, Encoding};
 
 use crate::foundation::{id, BOOL, NO, YES};
@@ -66,34 +64,6 @@ where
 {
     let queue = dispatch::Queue::main();
     queue.exec_sync(method);
-}
-
-/// Upstream core graphics does not implement Encode for certain things, so we wrap them here -
-/// these are only used in reading certain types passed to us from some delegate methods.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub struct CGSize {
-    /// The width of this size.
-    pub width: CGFloat,
-
-    /// The height of this size.
-    pub height: CGFloat
-}
-
-impl CGSize {
-    /// Create and return a new `CGSize`.
-    pub fn new(width: CGFloat, height: CGFloat) -> Self {
-        CGSize { width, height }
-    }
-
-    /// Create and return a `CGSizeZero` equivalent.
-    pub fn zero() -> Self {
-        CGSize { width: 0., height: 0. }
-    }
-}
-
-unsafe impl Encode for CGSize {
-    const ENCODING: Encoding = Encoding::Struct("CGSize", &[CGFloat::ENCODING, CGFloat::ENCODING]);
 }
 
 #[repr(C)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,8 +2,6 @@
 //! belong to. These are typically internal, and if you rely on them... well, don't be surprised if
 //! they go away one day.
 
-use core_foundation::base::CFIndex;
-
 use objc::rc::{Id, Shared};
 use objc::runtime::Object;
 use objc::{class, msg_send, sel};
@@ -64,26 +62,6 @@ where
 {
     let queue = dispatch::Queue::main();
     queue.exec_sync(method);
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub struct CFRange {
-    pub location: CFIndex,
-    pub length: CFIndex
-}
-
-impl CFRange {
-    pub fn init(location: CFIndex, length: CFIndex) -> CFRange {
-        CFRange {
-            location: location,
-            length: length
-        }
-    }
-}
-
-unsafe impl Encode for CFRange {
-    const ENCODING: Encoding = Encoding::Struct("CFRange", &[CFIndex::ENCODING, CFIndex::ENCODING]);
 }
 
 /// A helper method for ensuring that Cocoa is running in multi-threaded mode.

--- a/src/view/animator.rs
+++ b/src/view/animator.rs
@@ -1,5 +1,4 @@
-use core_graphics::base::CGFloat;
-
+use objc::foundation::CGFloat;
 use objc::rc::{Id, Shared};
 use objc::runtime::{Class, Object};
 use objc::{msg_send, msg_send_id, sel};

--- a/src/view/popover/mod.rs
+++ b/src/view/popover/mod.rs
@@ -1,4 +1,4 @@
-use core_graphics::geometry::CGRect;
+use objc::foundation::{NSRect, NSSize};
 use objc::rc::{Id, Shared};
 use objc::runtime::Object;
 use objc::{class, msg_send, msg_send_id, sel};
@@ -13,7 +13,7 @@ use crate::appkit::App;
 use crate::foundation::{id, nil, NSString};
 use crate::geometry::{Edge, Rect};
 use crate::layout::Layout;
-use crate::utils::{os, CGSize, Controller};
+use crate::utils::{os, Controller};
 use crate::view::{View, ViewController, ViewDelegate};
 
 #[derive(Debug, Eq, PartialEq)]
@@ -29,7 +29,7 @@ pub enum PopoverBehaviour {
 
 #[derive(Debug)]
 pub struct PopoverConfig {
-    pub content_size: CGSize,
+    pub content_size: NSSize,
     pub animates: bool,
     pub behaviour: PopoverBehaviour
 }
@@ -37,10 +37,7 @@ pub struct PopoverConfig {
 impl Default for PopoverConfig {
     fn default() -> Self {
         Self {
-            content_size: CGSize {
-                width: 320.0,
-                height: 320.0
-            },
+            content_size: NSSize::new(320.0, 320.0),
             animates: true,
             behaviour: PopoverBehaviour::Transient
         }
@@ -79,7 +76,7 @@ where
 impl<Content> Popover<Content> {
     /// Show a popover relative to a view
     pub fn show_popover<V: Layout>(&self, relative_to: Rect, view: &V, edge: Edge) {
-        let rect: CGRect = relative_to.into();
+        let rect: NSRect = relative_to.into();
         unsafe {
             view.with_backing_obj_mut(|obj| {
                 let _: () = msg_send![&*self.objc, showRelativeToRect:rect ofView: &*obj preferredEdge: edge as u32];
@@ -93,7 +90,7 @@ impl<Content> Popover<Content> {
         let window = App::main_window();
         unsafe {
             let content_view = window.content_view();
-            let rect: CGRect = rect.into();
+            let rect: NSRect = rect.into();
             let _: () = msg_send![&*self.objc, showRelativeToRect:rect ofView: content_view preferredEdge: edge as u32];
         }
     }

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -13,8 +13,7 @@
 //! Apple does not ship `WKWebView` on tvOS, and as a result this control is not provided on that
 //! platform.
 
-use core_graphics::geometry::CGRect;
-
+use objc::foundation::NSRect;
 use objc::rc::{Id, Owned, Shared};
 use objc::runtime::Object;
 use objc::{class, msg_send, msg_send_id, sel};
@@ -75,7 +74,7 @@ fn allocate_webview(mut config: WebViewConfig, objc_delegate: Option<&Object>) -
             }
         }
 
-        let zero: CGRect = Rect::zero().into();
+        let zero: NSRect = Rect::zero().into();
         let webview_alloc: id = msg_send![register_webview_class(), alloc];
         let webview: id = msg_send![webview_alloc, initWithFrame:zero configuration: &*config.objc];
 


### PR DESCRIPTION
Message sending now requires types to implement `Encode`, which these crates don't do (yet, though maybe they will, see https://github.com/servo/core-foundation-rs/pull/628). Since these crates are used quite infrequently, and we'll probably want to use `icrate` later on anyhow, this PR replaces them.