### PR TITLE
Fix `core-foundation` dependency cycle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 block = "0.1.6"
-core-foundation = { version = "0.9", features = ["with-chrono"] }
+core-foundation = "0.9"
 core-graphics = "0.22"
 dispatch = "0.2.0"
 infer = { version = "0.4", optional = true }


### PR DESCRIPTION
This was introduced by https://github.com/chronotope/chrono/pull/756.

Fixes https://github.com/ryanmcgrath/cacao/issues/43.

Simple fix: Don't use the `with-chrono` feature (which we didn't use for anything anyhow).