### PR TITLE
iOS support for label, text input, font, more tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,6 @@ required-features = ["appkit"]
 [[example]]
 name = "safe_area"
 required-features = ["appkit"]
+[[example]]
+name = "popover"
+required-features = ["appkit"]

--- a/examples/ios-beta/main.rs
+++ b/examples/ios-beta/main.rs
@@ -1,8 +1,8 @@
 use std::sync::RwLock;
 
-use cacao::uikit::{App, AppDelegate, Scene, SceneConfig, SceneConnectionOptions, SceneSession, Window, WindowSceneDelegate};
 use cacao::input::{TextField, TextFieldDelegate};
 use cacao::text::{Label, TextAlign};
+use cacao::uikit::{App, AppDelegate, Scene, SceneConfig, SceneConnectionOptions, SceneSession, Window, WindowSceneDelegate};
 
 use cacao::color::Color;
 use cacao::image::{Image, ImageView};
@@ -47,7 +47,7 @@ pub struct RootView {
     pub blue: View,
     pub label: Label,
     pub image: ImageView,
-    pub input: TextField<ConsoleLogger>,
+    pub input: TextField<ConsoleLogger>
 }
 
 impl Default for RootView {
@@ -57,7 +57,7 @@ impl Default for RootView {
             blue: View::new(),
             label: Label::new(),
             image: ImageView::new(),
-            input: TextField::with(ConsoleLogger("input_1".to_string())),
+            input: TextField::with(ConsoleLogger("input_1".to_string()))
         }
     }
 }
@@ -89,27 +89,22 @@ impl ViewDelegate for RootView {
         view.add_subview(&self.input);
 
         LayoutConstraint::activate(&[
-
             self.label.leading.constraint_equal_to(&view.leading).offset(16.),
             self.label.top.constraint_equal_to(&view.top).offset(16.),
             self.label.height.constraint_equal_to_constant(100.),
             self.label.trailing.constraint_equal_to(&view.trailing).offset(-16.),
-
             self.green.top.constraint_equal_to(&self.label.bottom).offset(16.),
             self.green.leading.constraint_equal_to(&view.leading).offset(16.),
             self.green.trailing.constraint_equal_to(&view.trailing).offset(-16.),
             self.green.height.constraint_equal_to_constant(120.),
-
             self.input.center_x.constraint_equal_to(&self.green.center_x),
             self.input.center_y.constraint_equal_to(&self.green.center_y),
-
             self.blue.top.constraint_equal_to(&self.green.bottom).offset(16.),
             self.blue.leading.constraint_equal_to(&view.leading).offset(16.),
             self.blue.trailing.constraint_equal_to(&view.trailing).offset(-16.),
             self.blue.bottom.constraint_equal_to(&view.bottom).offset(-16.),
-
             self.image.center_x.constraint_equal_to(&self.blue.center_x),
-            self.image.center_y.constraint_equal_to(&self.blue.center_y),
+            self.image.center_y.constraint_equal_to(&self.blue.center_y)
         ]);
     }
 }

--- a/examples/ios-beta/main.rs
+++ b/examples/ios-beta/main.rs
@@ -1,6 +1,8 @@
 use std::sync::RwLock;
 
 use cacao::uikit::{App, AppDelegate, Scene, SceneConfig, SceneConnectionOptions, SceneSession, Window, WindowSceneDelegate};
+use cacao::input::{TextField, TextFieldDelegate};
+use cacao::text::{Label, TextAlign};
 
 use cacao::color::Color;
 use cacao::image::{Image, ImageView};
@@ -15,22 +17,62 @@ impl AppDelegate for TestApp {
         SceneConfig::new("Default Configuration", session.role())
     }
 }
+#[derive(Debug, Default)]
+pub struct ConsoleLogger(String);
 
-#[derive(Default)]
+impl TextFieldDelegate for ConsoleLogger {
+    const NAME: &'static str = "ConsoleLogger";
+
+    fn text_should_begin_editing(&self, value: &str) -> bool {
+        println!("{} should begin editing: {}", self.0, value);
+        true
+    }
+
+    fn text_did_change(&self, value: &str) {
+        println!("{} text did change to {}", self.0, value);
+    }
+
+    fn text_did_end_editing(&self, value: &str) {
+        println!("{} did end editing: {}", self.0, value);
+    }
+
+    fn text_should_end_editing(&self, value: &str) -> bool {
+        println!("{} should end editing: {}", self.0, value);
+        true
+    }
+}
+
 pub struct RootView {
-    pub red: View,
     pub green: View,
     pub blue: View,
-    pub image: ImageView
+    pub label: Label,
+    pub image: ImageView,
+    pub input: TextField<ConsoleLogger>,
+}
+
+impl Default for RootView {
+    fn default() -> Self {
+        RootView {
+            green: View::new(),
+            blue: View::new(),
+            label: Label::new(),
+            image: ImageView::new(),
+            input: TextField::with(ConsoleLogger("input_1".to_string())),
+        }
+    }
 }
 
 impl ViewDelegate for RootView {
     const NAME: &'static str = "RootView";
 
     fn did_load(&mut self, view: View) {
-        self.red.set_background_color(Color::SystemRed);
-        self.red.layer.set_corner_radius(16.);
-        view.add_subview(&self.red);
+        self.label.set_text("my label");
+        self.label.set_text_color(Color::SystemWhite);
+        self.label.set_background_color(Color::SystemRed);
+        self.label.layer.set_corner_radius(16.);
+        self.label.set_text_alignment(TextAlign::Center);
+
+        view.add_subview(&self.label);
 
         self.green.set_background_color(Color::SystemGreen);
         view.add_subview(&self.green);
@@ -43,19 +85,31 @@ impl ViewDelegate for RootView {
         self.image.set_image(&Image::with_data(image_bytes));
         view.add_subview(&self.image);
 
+        self.input.set_text("my input box 1");
+        view.add_subview(&self.input);
+
         LayoutConstraint::activate(&[
-            self.red.top.constraint_equal_to(&view.top).offset(16.),
-            self.red.leading.constraint_equal_to(&view.leading).offset(16.),
-            self.red.trailing.constraint_equal_to(&view.trailing).offset(-16.),
-            self.red.height.constraint_equal_to_constant(100.),
-            self.green.top.constraint_equal_to(&self.red.bottom).offset(16.),
+
+            self.label.leading.constraint_equal_to(&view.leading).offset(16.),
+            self.label.top.constraint_equal_to(&view.top).offset(16.),
+            self.label.height.constraint_equal_to_constant(100.),
+            self.label.trailing.constraint_equal_to(&view.trailing).offset(-16.),
+
+            self.green.top.constraint_equal_to(&self.label.bottom).offset(16.),
             self.green.leading.constraint_equal_to(&view.leading).offset(16.),
             self.green.trailing.constraint_equal_to(&view.trailing).offset(-16.),
             self.green.height.constraint_equal_to_constant(120.),
+
+            self.input.center_x.constraint_equal_to(&self.green.center_x),
+            self.input.center_y.constraint_equal_to(&self.green.center_y),
+
             self.blue.top.constraint_equal_to(&self.green.bottom).offset(16.),
             self.blue.leading.constraint_equal_to(&view.leading).offset(16.),
             self.blue.trailing.constraint_equal_to(&view.trailing).offset(-16.),
-            self.blue.bottom.constraint_equal_to(&view.bottom).offset(-16.)
+            self.blue.bottom.constraint_equal_to(&view.bottom).offset(-16.),
+
+            self.image.center_x.constraint_equal_to(&self.blue.center_x),
+            self.image.center_y.constraint_equal_to(&self.blue.center_y),
         ]);
     }
 }

--- a/src/button/mod.rs
+++ b/src/button/mod.rs
@@ -353,5 +353,15 @@ impl Drop for Button {
 /// Registers an `NSButton` subclass, and configures it to hold some ivars
 /// for various things we need to store.
 fn register_class() -> *const Class {
-    load_or_register_class("NSButton", "RSTButton", |decl| unsafe {})
+    #[cfg(feature = "appkit")]
+    let super_class = "NSButton";
+    #[cfg(all(feature = "uikit", not(feature = "appkit")))]
+    let super_class = "UIButton";
+    load_or_register_class(super_class, "RSTButton", |decl| unsafe {})
+}
+
+
+#[test]
+fn test_button() {
+    let button = Button::new("foobar");
 }

--- a/src/button/mod.rs
+++ b/src/button/mod.rs
@@ -360,7 +360,6 @@ fn register_class() -> *const Class {
     load_or_register_class(super_class, "RSTButton", |decl| unsafe {})
 }
 
-
 #[test]
 fn test_button() {
     let button = Button::new("foobar");

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -8,9 +8,9 @@ use crate::layout::Layout;
 use crate::objc_access::ObjcAccess;
 use crate::utils::properties::ObjcProperty;
 
+use crate::layer::Layer;
 #[cfg(feature = "autolayout")]
 use crate::layout::{LayoutAnchorDimension, LayoutAnchorX, LayoutAnchorY};
-use crate::layer::Layer;
 
 #[cfg(feature = "appkit")]
 mod appkit;

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -10,6 +10,7 @@ use crate::utils::properties::ObjcProperty;
 
 #[cfg(feature = "autolayout")]
 use crate::layout::{LayoutAnchorDimension, LayoutAnchorX, LayoutAnchorY};
+use crate::layer::Layer;
 
 #[cfg(feature = "appkit")]
 mod appkit;
@@ -51,6 +52,10 @@ fn allocate_view(registration_fn: fn() -> *const Class) -> id {
 pub struct ImageView {
     /// A pointer to the Objective-C runtime view controller.
     pub objc: ObjcProperty,
+
+    /// References the underlying layer. This is consistent across AppKit & UIKit - in AppKit
+    /// we explicitly opt in to layer backed views.
+    pub layer: Layer,
 
     /// A pointer to the Objective-C runtime top layout constraint.
     #[cfg(feature = "autolayout")]
@@ -134,6 +139,8 @@ impl ImageView {
 
             #[cfg(feature = "autolayout")]
             center_y: LayoutAnchorY::center(view),
+
+            layer: Layer::wrap(unsafe { msg_send![view, layer] }),
 
             objc: ObjcProperty::retain(view)
         }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -44,7 +44,7 @@
 //! For more information on Autolayout, view the module or check out the examples folder.
 
 use objc::runtime::{Class, Object};
-use objc::{msg_send, sel, sel_impl, class};
+use objc::{class, msg_send, sel, sel_impl};
 use objc_id::ShareId;
 
 use crate::color::Color;
@@ -206,7 +206,7 @@ where
             (&mut *input).set_ivar(TEXTFIELD_DELEGATE_PTR, ptr as usize);
         };
         #[cfg(feature = "uikit")]
-        let _: () = unsafe {msg_send![input, setDelegate: input] };
+        let _: () = unsafe { msg_send![input, setDelegate: input] };
 
         let mut input = TextField {
             delegate: None,

--- a/src/input/uikit.rs
+++ b/src/input/uikit.rs
@@ -1,0 +1,92 @@
+use std::sync::Once;
+
+use objc::declare::ClassDecl;
+use objc::runtime::{Class, Object, Sel, BOOL};
+use objc::{class, msg_send, sel, sel_impl};
+use objc_id::Id;
+
+use crate::foundation::{id, load_or_register_class, NSString, NSUInteger, NO, YES};
+use crate::input::{TextFieldDelegate, TEXTFIELD_DELEGATE_PTR};
+use crate::utils::load;
+
+/// Called when editing this text field has ended (e.g. user pressed enter).
+extern "C" fn text_did_end_editing<T: TextFieldDelegate>(this: &mut Object, _: Sel, _info: id) {
+    let view = load::<T>(this, TEXTFIELD_DELEGATE_PTR);
+    let s = NSString::retain(unsafe { msg_send![this, text] });
+    view.text_did_end_editing(s.to_str());
+}
+
+extern "C" fn text_did_begin_editing<T: TextFieldDelegate>(this: &mut Object, _: Sel, _info: id) {
+    let view = load::<T>(this, TEXTFIELD_DELEGATE_PTR);
+    let s = NSString::retain(unsafe { msg_send![this, text] });
+    view.text_did_begin_editing(s.to_str());
+}
+
+extern "C" fn text_did_change<T: TextFieldDelegate>(this: &mut Object, _: Sel, _info: id) {
+    let view = load::<T>(this, TEXTFIELD_DELEGATE_PTR);
+    let s = NSString::retain(unsafe { msg_send![this, text] });
+    view.text_did_change(s.to_str());
+}
+
+extern "C" fn text_should_begin_editing<T: TextFieldDelegate>(this: &mut Object, _: Sel, _info: id) -> BOOL {
+    let view = load::<T>(this, TEXTFIELD_DELEGATE_PTR);
+    let s = NSString::retain(unsafe { msg_send![this, text] });
+
+    match view.text_should_begin_editing(s.to_str()) {
+        true => YES,
+        false => NO
+    }
+}
+
+extern "C" fn text_should_end_editing<T: TextFieldDelegate>(this: &mut Object, _: Sel, _info: id) -> BOOL {
+    let view = load::<T>(this, TEXTFIELD_DELEGATE_PTR);
+    let s = NSString::retain(unsafe { msg_send![this, text] });
+    match view.text_should_end_editing(s.to_str()) {
+        true => YES,
+        false => NO
+    }
+}
+
+/// Injects an `UITextField` subclass. This is used for the default views that don't use delegates - we
+/// have separate classes here since we don't want to waste cycles on methods that will never be
+/// used if there's no delegates.
+pub(crate) fn register_view_class() -> *const Class {
+    static mut VIEW_CLASS: *const Class = 0 as *const Class;
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| unsafe {
+        let superclass = class!(UITextField);
+        let decl = ClassDecl::new("RSTTextInputField", superclass).unwrap();
+        VIEW_CLASS = decl.register();
+    });
+
+    unsafe { VIEW_CLASS }
+}
+
+/// Injects an `UITextField` subclass, with some callback and pointer ivars for what we
+/// need to do.
+pub(crate) fn register_view_class_with_delegate<T: TextFieldDelegate>(instance: &T) -> *const Class {
+    load_or_register_class("UITextField", instance.subclass_name(), |decl| unsafe {
+        // A pointer to the "view controller" on the Rust side. It's expected that this doesn't
+        // move.
+        decl.add_ivar::<usize>(TEXTFIELD_DELEGATE_PTR);
+
+        decl.add_method(
+            sel!(textFieldDidEndEditing:),
+            text_did_end_editing::<T> as extern "C" fn(&mut Object, _, _)
+        );
+        decl.add_method(
+            sel!(textFieldDidBeginEditing:),
+            text_did_begin_editing::<T> as extern "C" fn(&mut Object, _, _)
+        );
+        decl.add_method(sel!(textFieldDidChangeSelection:), text_did_change::<T> as extern "C" fn(&mut Object, _, _));
+        decl.add_method(
+            sel!(textFieldShouldBeginEditing:),
+            text_should_begin_editing::<T> as extern "C" fn(&mut Object, Sel, id) -> BOOL
+        );
+        decl.add_method(
+            sel!(textFieldShouldEndEditing:),
+            text_should_end_editing::<T> as extern "C" fn(&mut Object, Sel, id) -> BOOL
+        );
+    })
+}

--- a/src/input/uikit.rs
+++ b/src/input/uikit.rs
@@ -79,7 +79,10 @@ pub(crate) fn register_view_class_with_delegate<T: TextFieldDelegate>(instance: 
             sel!(textFieldDidBeginEditing:),
             text_did_begin_editing::<T> as extern "C" fn(&mut Object, _, _)
         );
-        decl.add_method(sel!(textFieldDidChangeSelection:), text_did_change::<T> as extern "C" fn(&mut Object, _, _));
+        decl.add_method(
+            sel!(textFieldDidChangeSelection:),
+            text_did_change::<T> as extern "C" fn(&mut Object, _, _)
+        );
         decl.add_method(
             sel!(textFieldShouldBeginEditing:),
             text_should_begin_editing::<T> as extern "C" fn(&mut Object, Sel, id) -> BOOL

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub mod cloudkit;
 
 pub mod color;
 
-#[cfg(feature = "appkit")]
+#[cfg(any(feature = "appkit", feature = "uikit"))]
 pub mod control;
 
 #[cfg(feature = "appkit")]
@@ -140,7 +140,7 @@ pub mod geometry;
 #[cfg(any(feature = "appkit", feature = "uikit"))]
 pub mod image;
 
-#[cfg(feature = "appkit")]
+#[cfg(any(feature = "appkit", feature = "uikit"))]
 pub mod input;
 pub(crate) mod invoker;
 
@@ -170,7 +170,6 @@ pub mod switch;
 #[cfg(feature = "appkit")]
 pub mod select;
 
-#[cfg(feature = "appkit")]
 pub mod text;
 
 #[cfg(feature = "quicklook")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ pub mod pasteboard;
 #[cfg(feature = "appkit")]
 pub mod progress;
 
-#[cfg(feature = "appkit")]
+#[cfg(any(feature = "appkit", feature = "uikit"))]
 pub mod scrollview;
 
 #[cfg(feature = "appkit")]

--- a/src/listview/row/mod.rs
+++ b/src/listview/row/mod.rs
@@ -55,6 +55,7 @@ use crate::layer::Layer;
 use crate::layout::Layout;
 use crate::objc_access::ObjcAccess;
 use crate::utils::properties::ObjcProperty;
+#[cfg(all(feature = "appkit", target_os = "macos"))]
 use crate::view::{ViewAnimatorProxy, ViewDelegate};
 
 #[cfg(feature = "autolayout")]
@@ -96,6 +97,7 @@ fn allocate_view(registration_fn: fn() -> *const Class) -> id {
 #[derive(Debug)]
 pub struct ListViewRow<T = ()> {
     /// An object that supports limited animations. Can be cloned into animation closures.
+    #[cfg(all(feature = "appkit", target_os = "macos"))]
     pub animator: ViewAnimatorProxy,
 
     /// A pointer to the Objective-C runtime view controller.
@@ -163,6 +165,7 @@ impl ListViewRow {
         ListViewRow {
             delegate: None,
             objc: ObjcProperty::retain(view),
+            #[cfg(all(feature = "appkit", target_os = "macos"))]
             animator: ViewAnimatorProxy::new(view),
 
             #[cfg(feature = "autolayout")]
@@ -227,6 +230,7 @@ where
         let view = ListViewRow {
             delegate: Some(delegate),
             objc: ObjcProperty::retain(view),
+            #[cfg(all(feature = "appkit", target_os = "macos"))]
             animator: ViewAnimatorProxy::new(view),
 
             #[cfg(feature = "autolayout")]
@@ -283,6 +287,7 @@ where
         let mut view = ListViewRow {
             delegate: None,
             objc: ObjcProperty::retain(view),
+            #[cfg(all(feature = "appkit", target_os = "macos"))]
             animator: ViewAnimatorProxy::new(view),
 
             #[cfg(feature = "autolayout")]
@@ -335,6 +340,7 @@ where
         ListViewRow {
             delegate: None,
             objc: self.objc.clone(),
+            #[cfg(all(feature = "appkit", target_os = "macos"))]
             animator: self.animator.clone(),
 
             #[cfg(feature = "autolayout")]
@@ -384,6 +390,7 @@ impl<T> ListViewRow<T> {
             is_handle: true,
             layer: Layer::new(), // @TODO: Fix & return cloned true layer for this row.
             objc: self.objc.clone(),
+            #[cfg(all(feature = "appkit", target_os = "macos"))]
             animator: self.animator.clone(),
 
             #[cfg(feature = "autolayout")]

--- a/src/scrollview/mod.rs
+++ b/src/scrollview/mod.rs
@@ -50,7 +50,6 @@ use crate::color::Color;
 use crate::foundation::{id, nil, NSArray, NSString, NO, YES};
 use crate::layout::Layout;
 use crate::objc_access::ObjcAccess;
-use crate::pasteboard::PasteboardType;
 use crate::utils::properties::ObjcProperty;
 
 #[cfg(feature = "autolayout")]
@@ -62,11 +61,11 @@ mod appkit;
 #[cfg(feature = "appkit")]
 use appkit::{register_scrollview_class, register_scrollview_class_with_delegate};
 
-//#[cfg(feature = "uikit")]
-//mod ios;
+#[cfg(feature = "uikit")]
+mod uikit;
 
-//#[cfg(feature = "uikit")]
-//use ios::{register_view_class, register_view_class_with_delegate};
+#[cfg(all(feature = "uikit", not(feature = "appkit")))]
+use uikit::{register_view_class, register_view_class_with_delegate};
 
 mod traits;
 pub use traits::ScrollViewDelegate;
@@ -333,4 +332,10 @@ impl<T> Drop for ScrollView<T> {
             }
         }*/
     }
+}
+
+
+#[test]
+fn test_scrollview() {
+    let view = ScrollView::new();
 }

--- a/src/scrollview/mod.rs
+++ b/src/scrollview/mod.rs
@@ -334,7 +334,6 @@ impl<T> Drop for ScrollView<T> {
     }
 }
 
-
 #[test]
 fn test_scrollview() {
     let view = ScrollView::new();

--- a/src/scrollview/mod.rs
+++ b/src/scrollview/mod.rs
@@ -65,7 +65,7 @@ use appkit::{register_scrollview_class, register_scrollview_class_with_delegate}
 mod uikit;
 
 #[cfg(all(feature = "uikit", not(feature = "appkit")))]
-use uikit::{register_view_class, register_view_class_with_delegate};
+use uikit::{register_scrollview_class, register_scrollview_class_with_delegate};
 
 mod traits;
 pub use traits::ScrollViewDelegate;

--- a/src/scrollview/traits.rs
+++ b/src/scrollview/traits.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "appkit")]
 use crate::dragdrop::{DragInfo, DragOperation};
 use crate::scrollview::ScrollView;
 
@@ -22,24 +23,29 @@ pub trait ScrollViewDelegate {
     /// Called when this has been removed from the view heirarchy.
     fn did_disappear(&self, _animated: bool) {}
 
+    #[cfg(feature = "appkit")]
     /// Invoked when the dragged image enters destination bounds or frame; returns dragging operation to perform.
     fn dragging_entered(&self, _info: DragInfo) -> DragOperation {
         DragOperation::None
     }
 
+    #[cfg(feature = "appkit")]
     /// Invoked when the image is released, allowing the receiver to agree to or refuse drag operation.
     fn prepare_for_drag_operation(&self, _info: DragInfo) -> bool {
         false
     }
 
+    #[cfg(feature = "appkit")]
     /// Invoked after the released image has been removed from the screen, signaling the receiver to import the pasteboard data.
     fn perform_drag_operation(&self, _info: DragInfo) -> bool {
         false
     }
 
+    #[cfg(feature = "appkit")]
     /// Invoked when the dragging operation is complete, signaling the receiver to perform any necessary clean-up.
     fn conclude_drag_operation(&self, _info: DragInfo) {}
 
+    #[cfg(feature = "appkit")]
     /// Invoked when the dragged image exits the destination’s bounds rectangle (in the case of a view) or its frame
     /// rectangle (in the case of a window object).
     fn dragging_exited(&self, _info: DragInfo) {}

--- a/src/scrollview/uikit.rs
+++ b/src/scrollview/uikit.rs
@@ -1,0 +1,138 @@
+//! This module does one specific thing: register a custom `NSView` class that's... brought to the
+//! modern era.
+//!
+//! I kid, I kid.
+//!
+//! It just enforces that coordinates are judged from the top-left, which is what most people look
+//! for in the modern era. It also implements a few helpers for things like setting a background
+//! color, and enforcing layer backing by default.
+
+use std::sync::Once;
+
+use objc::declare::ClassDecl;
+use objc::runtime::{Class, Object, Sel, BOOL};
+use objc::{class, sel, sel_impl};
+use objc_id::Id;
+
+use crate::foundation::{id, NSUInteger, NO, YES};
+use crate::scrollview::{ScrollViewDelegate, SCROLLVIEW_DELEGATE_PTR};
+use crate::utils::load;
+
+/// Enforces normalcy, or: a needlessly cruel method in terms of the name. You get the idea though.
+extern "C" fn enforce_normalcy(_: &Object, _: Sel) -> BOOL {
+    return YES;
+}
+
+/*
+use crate::dragdrop::DragInfo;
+/// Called when a drag/drop operation has entered this view.
+extern "C" fn dragging_entered<T: ScrollViewDelegate>(this: &mut Object, _: Sel, info: id) -> NSUInteger {
+    let view = load::<T>(this, SCROLLVIEW_DELEGATE_PTR);
+    view.dragging_entered(DragInfo {
+        info: unsafe { Id::from_ptr(info) }
+    })
+    .into()
+}
+
+/// Called when a drag/drop operation has entered this view.
+extern "C" fn prepare_for_drag_operation<T: ScrollViewDelegate>(this: &mut Object, _: Sel, info: id) -> BOOL {
+    let view = load::<T>(this, SCROLLVIEW_DELEGATE_PTR);
+
+    match view.prepare_for_drag_operation(DragInfo {
+        info: unsafe { Id::from_ptr(info) }
+    }) {
+        true => YES,
+        false => NO
+    }
+}
+
+/// Called when a drag/drop operation has entered this view.
+extern "C" fn perform_drag_operation<T: ScrollViewDelegate>(this: &mut Object, _: Sel, info: id) -> BOOL {
+    let view = load::<T>(this, SCROLLVIEW_DELEGATE_PTR);
+
+    match view.perform_drag_operation(DragInfo {
+        info: unsafe { Id::from_ptr(info) }
+    }) {
+        true => YES,
+        false => NO
+    }
+}
+
+/// Called when a drag/drop operation has entered this view.
+extern "C" fn conclude_drag_operation<T: ScrollViewDelegate>(this: &mut Object, _: Sel, info: id) {
+    let view = load::<T>(this, SCROLLVIEW_DELEGATE_PTR);
+
+    view.conclude_drag_operation(DragInfo {
+        info: unsafe { Id::from_ptr(info) }
+    });
+}
+
+/// Called when a drag/drop operation has entered this view.
+extern "C" fn dragging_exited<T: ScrollViewDelegate>(this: &mut Object, _: Sel, info: id) {
+    let view = load::<T>(this, SCROLLVIEW_DELEGATE_PTR);
+
+    view.dragging_exited(DragInfo {
+        info: unsafe { Id::from_ptr(info) }
+    });
+}
+*/
+
+/// Injects an `UIScrollView` subclass.
+pub(crate) fn register_scrollview_class() -> *const Class {
+    static mut VIEW_CLASS: *const Class = 0 as *const Class;
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| unsafe {
+        let superclass = class!(UIScrollView);
+        let decl = ClassDecl::new("RSTScrollView", superclass).unwrap();
+        VIEW_CLASS = decl.register();
+    });
+
+    unsafe { VIEW_CLASS }
+}
+
+/// Injects an `NSView` subclass, with some callback and pointer ivars for what we
+/// need to do.
+pub(crate) fn register_scrollview_class_with_delegate<T: ScrollViewDelegate>() -> *const Class {
+    static mut VIEW_CLASS: *const Class = 0 as *const Class;
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| unsafe {
+        let superclass = class!(UIScrollView);
+        let mut decl = ClassDecl::new("RSTScrollViewWithDelegate", superclass).unwrap();
+
+        // A pointer to the "view controller" on the Rust side. It's expected that this doesn't
+        // move.
+        decl.add_ivar::<usize>(SCROLLVIEW_DELEGATE_PTR);
+
+        decl.add_method(sel!(isFlipped), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
+
+        /*
+        // Drag and drop operations (e.g, accepting files)
+        decl.add_method(
+            sel!(draggingEntered:),
+            dragging_entered::<T> as extern "C" fn(&mut Object, _, _) -> NSUInteger
+        );
+        decl.add_method(
+            sel!(prepareForDragOperation:),
+            prepare_for_drag_operation::<T> as extern "C" fn(&mut Object, _, _) -> BOOL
+        );
+        decl.add_method(
+            sel!(performDragOperation:),
+            perform_drag_operation::<T> as extern "C" fn(&mut Object, _, _) -> BOOL
+        );
+        decl.add_method(
+            sel!(concludeDragOperation:),
+            conclude_drag_operation::<T> as extern "C" fn(&mut Object, _, _)
+        );
+        decl.add_method(
+            sel!(draggingExited:),
+            dragging_exited::<T> as extern "C" fn(&mut Object, _, _)
+        );
+        */
+
+        VIEW_CLASS = decl.register();
+    });
+
+    unsafe { VIEW_CLASS }
+}

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -20,13 +20,13 @@ impl Default for Font {
     /// Returns the default `labelFont` on macOS.
     fn default() -> Self {
         let cls = Self::class();
-        let default_size: id = unsafe {msg_send![cls, labelFontSize]};
+        let default_size: id = unsafe { msg_send![cls, labelFontSize] };
 
         #[cfg(feature = "appkit")]
-        let font = Font(unsafe {ShareId::from_ptr(msg_send![cls, labelFontOfSize: default_size]) });
+        let font = Font(unsafe { ShareId::from_ptr(msg_send![cls, labelFontOfSize: default_size]) });
 
         #[cfg(all(feature = "uikit", not(feature = "appkit")))]
-        let font = Font(unsafe {ShareId::from_ptr(msg_send![cls, systemFontOfSize: default_size])});
+        let font = Font(unsafe { ShareId::from_ptr(msg_send![cls, systemFontOfSize: default_size]) });
         font
     }
 }

--- a/src/text/label/mod.rs
+++ b/src/text/label/mod.rs
@@ -49,8 +49,8 @@ use objc_id::ShareId;
 
 use crate::color::Color;
 use crate::foundation::{id, nil, NSArray, NSInteger, NSString, NSUInteger, NO, YES};
-use crate::layout::Layout;
 use crate::layer::Layer;
+use crate::layout::Layout;
 use crate::objc_access::ObjcAccess;
 use crate::text::{AttributedString, Font, LineBreakMode, TextAlign};
 use crate::utils::properties::ObjcProperty;
@@ -216,7 +216,6 @@ impl Label {
     }
 
     pub(crate) fn init<T>(view: id, delegate: Option<Box<T>>) -> Label<T> {
-
         Label {
             delegate,
 
@@ -371,17 +370,16 @@ impl<T> Label<T> {
     }
     #[cfg(all(feature = "uikit", not(feature = "appkit")))]
     pub fn get_text(&self) -> String {
-        self.objc
-            .get(|obj| {
-                let val : id = unsafe {msg_send![obj, text]};
-                // Through trial and error, this seems to return a null pointer when there's no
-                // text.
-                if val.is_null() {
-                    String::new()
-                } else {
-                    NSString::retain(val).to_string()
-                }
-            })
+        self.objc.get(|obj| {
+            let val: id = unsafe { msg_send![obj, text] };
+            // Through trial and error, this seems to return a null pointer when there's no
+            // text.
+            if val.is_null() {
+                String::new()
+            } else {
+                NSString::retain(val).to_string()
+            }
+        })
     }
 
     /// Sets the text alignment for this label.
@@ -465,7 +463,6 @@ impl<T> Drop for Label<T> {
         }*/
     }
 }
-
 
 #[test]
 fn test_label() {

--- a/src/text/label/mod.rs
+++ b/src/text/label/mod.rs
@@ -50,6 +50,7 @@ use objc_id::ShareId;
 use crate::color::Color;
 use crate::foundation::{id, nil, NSArray, NSInteger, NSString, NSUInteger, NO, YES};
 use crate::layout::Layout;
+use crate::layer::Layer;
 use crate::objc_access::ObjcAccess;
 use crate::text::{AttributedString, Font, LineBreakMode, TextAlign};
 use crate::utils::properties::ObjcProperty;
@@ -63,11 +64,11 @@ mod appkit;
 #[cfg(feature = "appkit")]
 use appkit::{register_view_class, register_view_class_with_delegate};
 
-//#[cfg(feature = "uikit")]
-//mod uikit;
+#[cfg(feature = "uikit")]
+mod uikit;
 
-//#[cfg(feature = "uikit")]
-//use uikit::{register_view_class, register_view_class_with_delegate};
+#[cfg(all(feature = "uikit", not(feature = "appkit")))]
+use uikit::{register_view_class, register_view_class_with_delegate};
 
 mod traits;
 pub use traits::LabelDelegate;
@@ -156,6 +157,10 @@ pub struct Label<T = ()> {
     /// A pointer to the delegate for this view.
     pub delegate: Option<Box<T>>,
 
+    /// References the underlying layer. This is consistent across AppKit & UIKit - in AppKit
+    /// we explicitly opt in to layer backed views.
+    pub layer: Layer,
+
     /// A pointer to the Objective-C runtime top layout constraint.
     #[cfg(feature = "autolayout")]
     pub top: LayoutAnchorY,
@@ -207,9 +212,13 @@ impl Label {
     /// Returns a default `Label`, suitable for
     pub fn new() -> Self {
         let view = allocate_view(register_view_class);
+        Self::init(view, None)
+    }
+
+    pub(crate) fn init<T>(view: id, delegate: Option<Box<T>>) -> Label<T> {
 
         Label {
-            delegate: None,
+            delegate,
 
             #[cfg(feature = "autolayout")]
             top: LayoutAnchorY::top(view),
@@ -241,6 +250,8 @@ impl Label {
             #[cfg(feature = "autolayout")]
             center_y: LayoutAnchorY::center(view),
 
+            layer: Layer::wrap(unsafe { msg_send![view, layer] }),
+
             objc: ObjcProperty::retain(view)
         }
     }
@@ -255,51 +266,12 @@ where
     pub fn with(delegate: T) -> Label<T> {
         let delegate = Box::new(delegate);
 
-        let label = allocate_view(register_view_class_with_delegate::<T>);
+        let view = allocate_view(register_view_class_with_delegate::<T>);
         unsafe {
             let ptr: *const T = &*delegate;
-            (&mut *label).set_ivar(LABEL_DELEGATE_PTR, ptr as usize);
+            (&mut *view).set_ivar(LABEL_DELEGATE_PTR, ptr as usize);
         };
-
-        let mut label = Label {
-            delegate: None,
-
-            #[cfg(feature = "autolayout")]
-            top: LayoutAnchorY::top(label),
-
-            #[cfg(feature = "autolayout")]
-            left: LayoutAnchorX::left(label),
-
-            #[cfg(feature = "autolayout")]
-            leading: LayoutAnchorX::leading(label),
-
-            #[cfg(feature = "autolayout")]
-            right: LayoutAnchorX::right(label),
-
-            #[cfg(feature = "autolayout")]
-            trailing: LayoutAnchorX::trailing(label),
-
-            #[cfg(feature = "autolayout")]
-            bottom: LayoutAnchorY::bottom(label),
-
-            #[cfg(feature = "autolayout")]
-            width: LayoutAnchorDimension::width(label),
-
-            #[cfg(feature = "autolayout")]
-            height: LayoutAnchorDimension::height(label),
-
-            #[cfg(feature = "autolayout")]
-            center_x: LayoutAnchorX::center(label),
-
-            #[cfg(feature = "autolayout")]
-            center_y: LayoutAnchorY::center(label),
-
-            objc: ObjcProperty::retain(label)
-        };
-
-        //(&mut delegate).did_load(label.clone_as_handle());
-        label.delegate = Some(delegate);
-        label
+        Label::init(view, Some(delegate))
     }
 }
 
@@ -342,6 +314,8 @@ impl<T> Label<T> {
             #[cfg(feature = "autolayout")]
             center_y: self.center_y.clone(),
 
+            layer: self.layer.clone(),
+
             objc: self.objc.clone()
         }
     }
@@ -372,28 +346,52 @@ impl<T> Label<T> {
         let s = NSString::new(text);
 
         self.objc.with_mut(|obj| unsafe {
+            #[cfg(feature = "appkit")]
             let _: () = msg_send![obj, setStringValue:&*s];
+            #[cfg(all(feature = "uikit", not(feature = "appkit")))]
+            let _: () = msg_send![obj, setText:&*s];
         });
     }
 
     /// Sets the attributed string to be the attributed string value on this label.
     pub fn set_attributed_text(&self, text: AttributedString) {
         self.objc.with_mut(|obj| unsafe {
+            #[cfg(feature = "appkit")]
             let _: () = msg_send![obj, setAttributedStringValue:&*text];
+            #[cfg(all(feature = "uikit", not(feature = "appkit")))]
+            let _: () = msg_send![obj, setAttributedText:&*text];
         });
     }
 
     /// Retrieve the text currently held in the label.
+    #[cfg(feature = "appkit")]
     pub fn get_text(&self) -> String {
         self.objc
             .get(|obj| unsafe { NSString::retain(msg_send![obj, stringValue]).to_string() })
+    }
+    #[cfg(all(feature = "uikit", not(feature = "appkit")))]
+    pub fn get_text(&self) -> String {
+        self.objc
+            .get(|obj| {
+                let val : id = unsafe {msg_send![obj, text]};
+                // Through trial and error, this seems to return a null pointer when there's no
+                // text.
+                if val.is_null() {
+                    String::new()
+                } else {
+                    NSString::retain(val).to_string()
+                }
+            })
     }
 
     /// Sets the text alignment for this label.
     pub fn set_text_alignment(&self, alignment: TextAlign) {
         self.objc.with_mut(|obj| unsafe {
             let alignment: NSInteger = alignment.into();
+            #[cfg(feature = "appkit")]
             let _: () = msg_send![obj, setAlignment: alignment];
+            #[cfg(all(feature = "uikit", not(feature = "appkit")))]
+            let _: () = msg_send![obj, setTextAlignment: alignment];
         });
     }
 
@@ -466,4 +464,20 @@ impl<T> Drop for Label<T> {
             }
         }*/
     }
+}
+
+
+#[test]
+fn test_label() {
+    let label = Label::new();
+    let text = label.get_text();
+    assert!(text.is_empty());
+    label.set_background_color(Color::SystemOrange);
+    label.set_text_color(Color::SystemRed);
+    label.set_text_alignment(TextAlign::Right);
+    label.set_text("foobar");
+    let text = label.get_text();
+    assert_eq!(text, "foobar".to_string());
+    label.set_font(Font::system(10.0));
+    label.set_attributed_text(AttributedString::new("foobar"));
 }

--- a/src/text/label/uikit.rs
+++ b/src/text/label/uikit.rs
@@ -1,0 +1,45 @@
+use std::sync::Once;
+
+use objc::declare::ClassDecl;
+use objc::runtime::{Class, Object, Sel, BOOL};
+use objc::{class, sel, sel_impl};
+use objc_id::Id;
+
+use crate::foundation::{id, NSUInteger, NO, YES};
+use crate::text::label::{LabelDelegate, LABEL_DELEGATE_PTR};
+
+/// Injects an `UILabel` subclass. This is used for the default views that don't use delegates - we
+/// have separate classes here since we don't want to waste cycles on methods that will never be
+/// used if there's no delegates.
+pub(crate) fn register_view_class() -> *const Class {
+    static mut VIEW_CLASS: *const Class = 0 as *const Class;
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| unsafe {
+        let superclass = class!(UILabel);
+        let decl = ClassDecl::new("RSTTextField", superclass).unwrap();
+        VIEW_CLASS = decl.register();
+    });
+
+    unsafe { VIEW_CLASS }
+}
+
+/// Injects an `UILabel` subclass, with some callback and pointer ivars for what we
+/// need to do.
+pub(crate) fn register_view_class_with_delegate<T: LabelDelegate>() -> *const Class {
+    static mut VIEW_CLASS: *const Class = 0 as *const Class;
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| unsafe {
+        let superclass = class!(UIView);
+        let mut decl = ClassDecl::new("RSTTextFieldWithDelegate", superclass).unwrap();
+
+        // A pointer to the "view controller" on the Rust side. It's expected that this doesn't
+        // move.
+        decl.add_ivar::<usize>(LABEL_DELEGATE_PTR);
+
+        VIEW_CLASS = decl.register();
+    });
+
+    unsafe { VIEW_CLASS }
+}

--- a/src/uikit/app/mod.rs
+++ b/src/uikit/app/mod.rs
@@ -155,12 +155,8 @@ where
         let cls = register_app_class();
         let dl = register_app_delegate_class::<T>();
 
-        let cls_name: id = unsafe {
-            msg_send![cls, className]
-        };
-        let dl_name : id = unsafe {
-            msg_send![dl, className]
-        };
+        let cls_name: id = unsafe { msg_send![cls, className] };
+        let dl_name: id = unsafe { msg_send![dl, className] };
 
         unsafe {
             UIApplicationMain(c_args.len() as c_int, c_args.as_ptr(), cls_name, dl_name);

--- a/src/uikit/app/mod.rs
+++ b/src/uikit/app/mod.rs
@@ -83,7 +83,7 @@ pub struct App<T = (), W = (), F = ()> {
     pub delegate: Box<T>,
     pub vendor: Box<F>,
     pub pool: AutoReleasePool,
-    _w: std::marker::PhantomData<W>,
+    _w: std::marker::PhantomData<W>
 }
 
 // Temporary. ;P
@@ -97,7 +97,7 @@ impl<T, W, F> App<T, W, F>
 where
     T: AppDelegate + 'static,
     W: WindowSceneDelegate,
-    F: Fn() -> Box<W>,
+    F: Fn() -> Box<W>
 {
     /// iOS manages creating a new Application (`UIApplication`) differently than you'd expect if
     /// you were looking at the macOS side of things.
@@ -134,14 +134,14 @@ where
             delegate: app_delegate,
             vendor,
             pool,
-            _w: std::marker::PhantomData,
+            _w: std::marker::PhantomData
         }
     }
 }
 
 impl<T, W, F> App<T, W, F>
 where
-    T: AppDelegate + 'static,
+    T: AppDelegate + 'static
 {
     /// Handles calling through to `UIApplicationMain()`, ensuring that it's using our custom
     /// `UIApplication` and `UIApplicationDelegate` classes.

--- a/src/uikit/app/mod.rs
+++ b/src/uikit/app/mod.rs
@@ -139,7 +139,10 @@ where
     }
 }
 
-impl<T, W, F> App<T, W, F> {
+impl<T, W, F> App<T, W, F>
+where
+    T: AppDelegate + 'static,
+{
     /// Handles calling through to `UIApplicationMain()`, ensuring that it's using our custom
     /// `UIApplication` and `UIApplicationDelegate` classes.
     pub fn run(&self) {
@@ -149,11 +152,18 @@ impl<T, W, F> App<T, W, F> {
 
         let c_args = args.iter().map(|arg| arg.as_ptr()).collect::<Vec<*const c_char>>();
 
-        let mut s = NSString::new("RSTApplication");
-        let mut s2 = NSString::new("RSTAppDelegate");
+        let cls = register_app_class();
+        let dl = register_app_delegate_class::<T>();
+
+        let cls_name: id = unsafe {
+            msg_send![cls, className]
+        };
+        let dl_name : id = unsafe {
+            msg_send![dl, className]
+        };
 
         unsafe {
-            UIApplicationMain(c_args.len() as c_int, c_args.as_ptr(), s.into(), s2.into());
+            UIApplicationMain(c_args.len() as c_int, c_args.as_ptr(), cls_name, dl_name);
         }
 
         self.pool.drain();

--- a/src/uikit/app/mod.rs
+++ b/src/uikit/app/mod.rs
@@ -83,7 +83,7 @@ pub struct App<T = (), W = (), F = ()> {
     pub delegate: Box<T>,
     pub vendor: Box<F>,
     pub pool: AutoReleasePool,
-    _w: std::marker::PhantomData<W>
+    _w: std::marker::PhantomData<W>,
 }
 
 // Temporary. ;P
@@ -97,7 +97,7 @@ impl<T, W, F> App<T, W, F>
 where
     T: AppDelegate + 'static,
     W: WindowSceneDelegate,
-    F: Fn() -> Box<W>
+    F: Fn() -> Box<W>,
 {
     /// iOS manages creating a new Application (`UIApplication`) differently than you'd expect if
     /// you were looking at the macOS side of things.
@@ -134,7 +134,7 @@ where
             delegate: app_delegate,
             vendor,
             pool,
-            _w: std::marker::PhantomData
+            _w: std::marker::PhantomData,
         }
     }
 }

--- a/src/uikit/scene/config.rs
+++ b/src/uikit/scene/config.rs
@@ -25,7 +25,7 @@ impl SceneConfig {
             let _: () = msg_send![config, setSceneClass: class!(UIWindowScene)];
 
             // TODO: use register_window_scene_delegate_class rather than load_or_register_class.
-            let window_delegate = load_or_register_class("UIResponder", "RSTWindowSceneDelegate", |decl| unsafe { });
+            let window_delegate = load_or_register_class("UIResponder", "RSTWindowSceneDelegate", |decl| unsafe {});
             let _: () = msg_send![config, setDelegateClass: window_delegate];
 
             Id::from_ptr(config)

--- a/src/uikit/scene/config.rs
+++ b/src/uikit/scene/config.rs
@@ -4,7 +4,6 @@ use objc_id::Id;
 
 use crate::foundation::{id, load_or_register_class, ClassMap, NSString};
 
-
 use crate::uikit::scene::SessionRole;
 
 /// A wrapper for UISceneConfiguration.

--- a/src/uikit/scene/config.rs
+++ b/src/uikit/scene/config.rs
@@ -2,7 +2,8 @@ use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl};
 use objc_id::Id;
 
-use crate::foundation::{id, NSString, load_or_register_class};
+use crate::foundation::{id, load_or_register_class, NSString};
+
 use crate::uikit::scene::SessionRole;
 
 /// A wrapper for UISceneConfiguration.

--- a/src/uikit/scene/config.rs
+++ b/src/uikit/scene/config.rs
@@ -2,7 +2,7 @@ use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl};
 use objc_id::Id;
 
-use crate::foundation::{id, NSString};
+use crate::foundation::{id, NSString, load_or_register_class};
 use crate::uikit::scene::SessionRole;
 
 /// A wrapper for UISceneConfiguration.
@@ -23,7 +23,10 @@ impl SceneConfig {
             let config: id = msg_send![cls, configurationWithName:name sessionRole:role];
 
             let _: () = msg_send![config, setSceneClass: class!(UIWindowScene)];
-            let _: () = msg_send![config, setDelegateClass: class!(RSTWindowSceneDelegate)];
+
+            // TODO: use register_window_scene_delegate_class rather than load_or_register_class.
+            let window_delegate = load_or_register_class("UIResponder", "RSTWindowSceneDelegate", |decl| unsafe { });
+            let _: () = msg_send![config, setDelegateClass: window_delegate];
 
             Id::from_ptr(config)
         })

--- a/src/uikit/scene/config.rs
+++ b/src/uikit/scene/config.rs
@@ -2,7 +2,9 @@ use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl};
 use objc_id::Id;
 
-use crate::foundation::{id, ClassMap, load_or_register_class, NSString};
++use crate::foundation::{id, load_or_register_class, ClassMap, NSString};
+
+
 use crate::uikit::scene::SessionRole;
 
 /// A wrapper for UISceneConfiguration.

--- a/src/uikit/scene/config.rs
+++ b/src/uikit/scene/config.rs
@@ -2,7 +2,7 @@ use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl};
 use objc_id::Id;
 
-+use crate::foundation::{id, load_or_register_class, ClassMap, NSString};
+use crate::foundation::{id, load_or_register_class, ClassMap, NSString};
 
 
 use crate::uikit::scene::SessionRole;

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -77,7 +77,9 @@ mod splitviewcontroller;
 #[cfg(feature = "appkit")]
 pub use splitviewcontroller::SplitViewController;
 
+#[cfg(feature = "appkit")]
 mod popover;
+#[cfg(feature = "appkit")]
 pub use popover::*;
 mod traits;
 pub use traits::ViewDelegate;

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -347,3 +347,10 @@ impl<T> Drop for View<T> {
         }
     }
 }
+
+#[test]
+fn test_view() {
+    let view = View::new();
+    let clone = view.clone_as_handle();
+    view.set_background_color(Color::SystemGreen);
+}


### PR DESCRIPTION
I was on vacation last week and did this for fun so it's a bit disorganized. I started out doing unit tests and then got off track. This PR should probably be broken up into a few things.

#### changes
* `layer` on `ImageView`
* Added uikit support for `Label` via `UILabel` 
* `TextField` and `TextFieldDelegate` via`UITextField` (though, this uses itself as a delegate which seems less than ideal)
* `Font` unit tests and what I think is an okay `impl Default` for `Font` with uikit.
* `ios-beta` has a `Label`, `TextView<ConsolLogger>` and the `ImageView` is in the center of the 3rd view: 
 <img width="320" alt="image" src="https://user-images.githubusercontent.com/1163510/187473990-2c4f0887-e548-4f0c-8ee9-562a90a6c8dc.png">


#### Tests on:
* Partial on `Label`
* Full on `Font`
* Partial on `TextView`
* Minimal on `View`.


#### Protip:

There's not a great way to develop for mutually exclusive feature flags but what I have found is that if we structure things like:

```rust
#[cfg(feature = "appkit")]
mod appkit;

#[cfg(feature = "appkit")]
use appkit::{register_view_class, register_view_class_with_delegate};

#[cfg(feature = "uikit")]
mod uikit;

#[cfg(all(feature = "uikit", not(feature = "appkit")))]
use uikit::{register_view_class, register_view_class_with_delegate};
```
In an editor config (I use vim with an LSP client and rust-analyzer) enable both of those feature flags you can reasonably navigate the codebase. The "jump to definition` of `register_view_class` is this case would go to `appkit` definition but to get to the `uikit` definition, you have to jump to definition of the `mod uikit` and then the `register_view_class`.

Here's the `.vim/settings.json` I used in this PR (I think this is either identically or similar for most other setups):
```json
{
    "rust-analyzer": {
        "cargo": {
            "target": "aarch64-apple-ios-sim",
            "features": ["uikit", "autolayout","appkit", "cloudkit", "user-notifications", "quicklook", "webview"],
            "noDefaultFeatures": true
        },
        "initialization_options": {
            "cargo": {
                "buildScripts": {
                    "enable": true
                }
            },
            "completion": { "autoimport": {"enable": true } },
            "procMacro": {
                "enable": true
            }
        }
    }
}
```