### PR TITLE
feat: provide a rust toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+# https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+channel = "nightly-2022-10-15"
+profile = "default"


### PR DESCRIPTION
In order to establish an specific Rust version while working on this repository a
`rust-toolchain.toml` file is provided which will make sure contributors use an
specific Rust + Ngihtly version.