### PR TITLE
Fix iOS CI and update infer dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         xcrun simctl list runtimes
         # Launch the simulator
         RUNTIME_ID=$(xcrun simctl list runtimes | grep iOS | cut -d ' ' -f 7 | tail -1)
-        SIM_ID=$(xcrun simctl create My-iphone-se com.apple.CoreSimulator.SimDeviceType.iPhone-SE $RUNTIME_ID)
+        SIM_ID=$(xcrun simctl create My-iphone-se com.apple.CoreSimulator.SimDeviceType.iPhone-14 $RUNTIME_ID)
         xcrun simctl boot $SIM_ID
 
     - name: Dinghy test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ block = "0.1.6"
 core-foundation = "0.9"
 core-graphics = "0.22"
 dispatch = "0.2.0"
-infer = { version = "0.9", optional = true }
+infer = { version = "0.11", optional = true }
 lazy_static = "1.4.0"
 libc = "0.2"
 objc = "0.2.7"


### PR DESCRIPTION
I think the issue is that the iPhone SE device id changed with different versions of macOS/sdk. I chose to make it the iPhone 14 as that is likely to increment by a version and be [broken in ~60 months](https://en.wikipedia.org/wiki/List_of_iOS_and_iPadOS_devices#iPhone).

Closes #65.