### PR TITLE
implement acceptsFirstMouse on webview

### DIFF
--- a/src/webview/class.rs
+++ b/src/webview/class.rs
@@ -9,7 +9,7 @@ use std::sync::Once;
 use block::Block;
 
 use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel};
+use objc::runtime::{Class, Object, Sel, BOOL};
 use objc::{class, msg_send, sel, sel_impl};
 
 use crate::foundation::{id, load_or_register_class, nil, NSArray, NSInteger, NSString, NO, YES};
@@ -166,11 +166,21 @@ extern "C" fn handle_download<T: WebViewDelegate>(this: &Object, _: Sel, downloa
     });
 }
 
+/// Whether the view should be sent a mouseDown event for the first click when not focused.
+extern "C" fn accepts_first_mouse(_: &mut Object, _: Sel, _: id) -> BOOL {
+    YES
+}
+
 /// Registers an `NSViewController` that we effectively turn into a `WebViewController`. Acts as
 /// both a subclass of `NSViewController` and a delegate of the held `WKWebView` (for the various
 /// varieties of delegates needed there).
 pub fn register_webview_class() -> *const Class {
-    load_or_register_class("WKWebView", "CacaoWebView", |decl| unsafe {})
+    load_or_register_class("WKWebView", "CacaoWebView", |decl| unsafe {
+        decl.add_method(
+            sel!(acceptsFirstMouse:),
+            accepts_first_mouse as extern "C" fn(&mut Object, Sel, id) -> BOOL
+        );
+    })
 }
 
 /// Registers an `NSViewController` that we effectively turn into a `WebViewController`. Acts as


### PR DESCRIPTION
this change implements the `acceptsFirstMouse` method on the webview class always returning `YES` from it.

> By default, a mouse-down event in a window that isn’t the key window simply brings the window forward and makes it key; the event isn’t sent to the NSView object over which the mouse click occurs. The NSView can claim an initial mouse-down event, however, by overriding [acceptsFirstMouse:](https://developer.apple.com/documentation/appkit/nsview/1483410-acceptsfirstmouse) to return YES.

https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/HandlingMouseEvents/HandlingMouseEvents.html

there are at least two remaining questions:
1. should the return value be configurable via the api? e.g. `webview.set_accepts_first_mouse(bool)`
2. should this also be implemented on other view classes in cacao?

i can't think of a scenario where someone wouldn't want a webview to behave this way since swallowing the first mouse-down event on a window seems like bad UX to me. i might be missing something obvious though.