### PR TITLE
Fixes possible duplicate objc class registration.

### DIFF
--- a/examples/popover.rs
+++ b/examples/popover.rs
@@ -15,35 +15,29 @@ use cacao::text::{Font, Label};
 use cacao::view::{Popover, PopoverConfig, View, ViewController, ViewDelegate};
 
 struct BasicApp {
-    window: WindowController<MyWindow>,
+    window: WindowController<MyWindow>
 }
 
 impl AppDelegate for BasicApp {
     fn did_finish_launching(&self) {
         App::set_menu(vec![
-            Menu::new(
-                "",
-                vec![
-                    MenuItem::Services,
-                    MenuItem::Separator,
-                    MenuItem::Hide,
-                    MenuItem::HideOthers,
-                    MenuItem::ShowAll,
-                    MenuItem::Separator,
-                    MenuItem::Quit,
-                ],
-            ),
+            Menu::new("", vec![
+                MenuItem::Services,
+                MenuItem::Separator,
+                MenuItem::Hide,
+                MenuItem::HideOthers,
+                MenuItem::ShowAll,
+                MenuItem::Separator,
+                MenuItem::Quit,
+            ]),
             Menu::new("File", vec![MenuItem::CloseWindow]),
             Menu::new("View", vec![MenuItem::EnterFullScreen]),
-            Menu::new(
-                "Window",
-                vec![
-                    MenuItem::Minimize,
-                    MenuItem::Zoom,
-                    MenuItem::Separator,
-                    MenuItem::new("Bring All to Front"),
-                ],
-            ),
+            Menu::new("Window", vec![
+                MenuItem::Minimize,
+                MenuItem::Zoom,
+                MenuItem::Separator,
+                MenuItem::new("Bring All to Front"),
+            ]),
         ]);
 
         App::activate();
@@ -58,7 +52,7 @@ impl AppDelegate for BasicApp {
 
 #[derive(Default)]
 struct MyWindow {
-    controller: Option<ViewController<PopoverExampleContentView>>,
+    controller: Option<ViewController<PopoverExampleContentView>>
 }
 
 impl WindowDelegate for MyWindow {
@@ -87,25 +81,22 @@ impl MyWindow {
 }
 
 fn main() {
-    App::new(
-        "com.test.window-delegate",
-        BasicApp {
-            window: WindowController::with(WindowConfig::default(), MyWindow::default()),
-        },
-    )
+    App::new("com.test.window-delegate", BasicApp {
+        window: WindowController::with(WindowConfig::default(), MyWindow::default())
+    })
     .run();
 }
 
 #[derive(Clone, Debug)]
 pub enum Msg {
-    Click,
+    Click
 }
 
 #[derive(Debug, Default)]
 struct PopoverExampleContentView {
     view: Option<View>,
     button: Option<Button>,
-    popover: Option<Popover<PopoverExampleContentViewController>>,
+    popover: Option<Popover<PopoverExampleContentViewController>>
 }
 
 impl PopoverExampleContentView {
@@ -113,7 +104,7 @@ impl PopoverExampleContentView {
         Self {
             view: None,
             button: None,
-            popover: None,
+            popover: None
         }
     }
 
@@ -123,7 +114,7 @@ impl PopoverExampleContentView {
                 let Some(ref popover) = self.popover else { return };
                 let Some(ref button) = self.button else { return };
                 popover.show_popover(Rect::zero(), button, Edge::MaxY);
-            },
+            }
         }
     }
 }
@@ -147,7 +138,7 @@ impl ViewDelegate for PopoverExampleContentView {
 
         LayoutConstraint::activate(&[
             button.center_x.constraint_equal_to(&view.center_x),
-            button.center_y.constraint_equal_to(&view.center_y),
+            button.center_y.constraint_equal_to(&view.center_y)
         ]);
 
         self.view = Some(view);
@@ -173,7 +164,7 @@ impl Dispatcher for BasicApp {
 
 #[derive(Debug)]
 struct PopoverExampleContentViewController {
-    pub label: Label,
+    pub label: Label
 }
 
 impl PopoverExampleContentViewController {

--- a/src/appkit/app/class.rs
+++ b/src/appkit/app/class.rs
@@ -2,27 +2,11 @@
 //! creates a custom `NSApplication` subclass that currently does nothing; this is meant as a hook
 //! for potential future use.
 
-use std::sync::Once;
-
-use objc::class;
-use objc::declare::ClassDecl;
 use objc::runtime::Class;
+
+use crate::foundation::load_or_register_class;
 
 /// Used for injecting a custom NSApplication. Currently does nothing.
 pub(crate) fn register_app_class() -> *const Class {
-    static mut APP_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTApplication";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { APP_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(NSApplication);
-            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-            APP_CLASS = decl.register();
-        });
-    }
-
-    unsafe { APP_CLASS }
+    load_or_register_class("NSApplication", "RSTApplication", |decl| unsafe {})
 }

--- a/src/appkit/app/class.rs
+++ b/src/appkit/app/class.rs
@@ -12,12 +12,17 @@ use objc::runtime::Class;
 pub(crate) fn register_app_class() -> *const Class {
     static mut APP_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTApplication";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSApplication);
-        let decl = ClassDecl::new("RSTApplication", superclass).unwrap();
-        APP_CLASS = decl.register();
-    });
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { APP_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSApplication);
+            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            APP_CLASS = decl.register();
+        });
+    }
 
     unsafe { APP_CLASS }
 }

--- a/src/appkit/app/delegate.rs
+++ b/src/appkit/app/delegate.rs
@@ -297,173 +297,178 @@ extern "C" fn delegate_handles_key<T: AppDelegate>(this: &Object, _: Sel, _: id,
 pub(crate) fn register_app_delegate_class<T: AppDelegate + AppDelegate>() -> *const Class {
     static mut DELEGATE_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTAppDelegate";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSObject);
-        let mut decl = ClassDecl::new("RSTAppDelegate", superclass).unwrap();
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { DELEGATE_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSObject);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
 
-        decl.add_ivar::<usize>(APP_PTR);
+            decl.add_ivar::<usize>(APP_PTR);
 
-        // Launching Applications
-        decl.add_method(
-            sel!(applicationWillFinishLaunching:),
-            will_finish_launching::<T> as extern "C" fn(&Object, _, _)
-        );
-        decl.add_method(
-            sel!(applicationDidFinishLaunching:),
-            did_finish_launching::<T> as extern "C" fn(&Object, _, _)
-        );
+            // Launching Applications
+            decl.add_method(
+                sel!(applicationWillFinishLaunching:),
+                will_finish_launching::<T> as extern "C" fn(&Object, _, _)
+            );
+            decl.add_method(
+                sel!(applicationDidFinishLaunching:),
+                did_finish_launching::<T> as extern "C" fn(&Object, _, _)
+            );
 
-        // Managing Active Status
-        decl.add_method(
-            sel!(applicationWillBecomeActive:),
-            will_become_active::<T> as extern "C" fn(&Object, _, _)
-        );
-        decl.add_method(
-            sel!(applicationDidBecomeActive:),
-            did_become_active::<T> as extern "C" fn(&Object, _, _)
-        );
-        decl.add_method(
-            sel!(applicationWillResignActive:),
-            will_resign_active::<T> as extern "C" fn(&Object, _, _)
-        );
-        decl.add_method(
-            sel!(applicationDidResignActive:),
-            did_resign_active::<T> as extern "C" fn(&Object, _, _)
-        );
+            // Managing Active Status
+            decl.add_method(
+                sel!(applicationWillBecomeActive:),
+                will_become_active::<T> as extern "C" fn(&Object, _, _)
+            );
+            decl.add_method(
+                sel!(applicationDidBecomeActive:),
+                did_become_active::<T> as extern "C" fn(&Object, _, _)
+            );
+            decl.add_method(
+                sel!(applicationWillResignActive:),
+                will_resign_active::<T> as extern "C" fn(&Object, _, _)
+            );
+            decl.add_method(
+                sel!(applicationDidResignActive:),
+                did_resign_active::<T> as extern "C" fn(&Object, _, _)
+            );
 
-        // Terminating Applications
-        decl.add_method(
-            sel!(applicationShouldTerminate:),
-            should_terminate::<T> as extern "C" fn(&Object, _, _) -> NSUInteger
-        );
-        decl.add_method(
-            sel!(applicationWillTerminate:),
-            will_terminate::<T> as extern "C" fn(&Object, _, _)
-        );
-        decl.add_method(
-            sel!(applicationShouldTerminateAfterLastWindowClosed:),
-            should_terminate_after_last_window_closed::<T> as extern "C" fn(&Object, _, _) -> BOOL
-        );
+            // Terminating Applications
+            decl.add_method(
+                sel!(applicationShouldTerminate:),
+                should_terminate::<T> as extern "C" fn(&Object, _, _) -> NSUInteger
+            );
+            decl.add_method(
+                sel!(applicationWillTerminate:),
+                will_terminate::<T> as extern "C" fn(&Object, _, _)
+            );
+            decl.add_method(
+                sel!(applicationShouldTerminateAfterLastWindowClosed:),
+                should_terminate_after_last_window_closed::<T> as extern "C" fn(&Object, _, _) -> BOOL
+            );
 
-        // Hiding Applications
-        decl.add_method(sel!(applicationWillHide:), will_hide::<T> as extern "C" fn(&Object, _, _));
-        decl.add_method(sel!(applicationDidHide:), did_hide::<T> as extern "C" fn(&Object, _, _));
-        decl.add_method(sel!(applicationWillUnhide:), will_unhide::<T> as extern "C" fn(&Object, _, _));
-        decl.add_method(sel!(applicationDidUnhide:), did_unhide::<T> as extern "C" fn(&Object, _, _));
+            // Hiding Applications
+            decl.add_method(sel!(applicationWillHide:), will_hide::<T> as extern "C" fn(&Object, _, _));
+            decl.add_method(sel!(applicationDidHide:), did_hide::<T> as extern "C" fn(&Object, _, _));
+            decl.add_method(sel!(applicationWillUnhide:), will_unhide::<T> as extern "C" fn(&Object, _, _));
+            decl.add_method(sel!(applicationDidUnhide:), did_unhide::<T> as extern "C" fn(&Object, _, _));
 
-        // Managing Windows
-        decl.add_method(sel!(applicationWillUpdate:), will_update::<T> as extern "C" fn(&Object, _, _));
-        decl.add_method(sel!(applicationDidUpdate:), did_update::<T> as extern "C" fn(&Object, _, _));
-        decl.add_method(
-            sel!(applicationShouldHandleReopen:hasVisibleWindows:),
-            should_handle_reopen::<T> as extern "C" fn(&Object, _, _, BOOL) -> BOOL
-        );
+            // Managing Windows
+            decl.add_method(sel!(applicationWillUpdate:), will_update::<T> as extern "C" fn(&Object, _, _));
+            decl.add_method(sel!(applicationDidUpdate:), did_update::<T> as extern "C" fn(&Object, _, _));
+            decl.add_method(
+                sel!(applicationShouldHandleReopen:hasVisibleWindows:),
+                should_handle_reopen::<T> as extern "C" fn(&Object, _, _, BOOL) -> BOOL
+            );
 
-        // Dock Menu
-        decl.add_method(
-            sel!(applicationDockMenu:),
-            dock_menu::<T> as extern "C" fn(&Object, _, _) -> id
-        );
+            // Dock Menu
+            decl.add_method(
+                sel!(applicationDockMenu:),
+                dock_menu::<T> as extern "C" fn(&Object, _, _) -> id
+            );
 
-        // Displaying Errors
-        decl.add_method(
-            sel!(application:willPresentError:),
-            will_present_error::<T> as extern "C" fn(&Object, _, _, id) -> id
-        );
+            // Displaying Errors
+            decl.add_method(
+                sel!(application:willPresentError:),
+                will_present_error::<T> as extern "C" fn(&Object, _, _, id) -> id
+            );
 
-        // Managing the Screen
-        decl.add_method(
-            sel!(applicationDidChangeScreenParameters:),
-            did_change_screen_parameters::<T> as extern "C" fn(&Object, _, _)
-        );
-        decl.add_method(
-            sel!(applicationDidChangeOcclusionState:),
-            did_change_occlusion_state::<T> as extern "C" fn(&Object, _, _)
-        );
+            // Managing the Screen
+            decl.add_method(
+                sel!(applicationDidChangeScreenParameters:),
+                did_change_screen_parameters::<T> as extern "C" fn(&Object, _, _)
+            );
+            decl.add_method(
+                sel!(applicationDidChangeOcclusionState:),
+                did_change_occlusion_state::<T> as extern "C" fn(&Object, _, _)
+            );
 
-        // User Activities
-        decl.add_method(
-            sel!(application:willContinueUserActivityWithType:),
-            will_continue_user_activity_with_type::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
-        );
-        decl.add_method(
-            sel!(application:continueUserActivity:restorationHandler:),
-            continue_user_activity::<T> as extern "C" fn(&Object, _, _, id, id) -> BOOL
-        );
-        decl.add_method(
-            sel!(application:didFailToContinueUserActivityWithType:error:),
-            failed_to_continue_user_activity::<T> as extern "C" fn(&Object, _, _, id, id)
-        );
-        decl.add_method(
-            sel!(application:didUpdateUserActivity:),
-            did_update_user_activity::<T> as extern "C" fn(&Object, _, _, id)
-        );
+            // User Activities
+            decl.add_method(
+                sel!(application:willContinueUserActivityWithType:),
+                will_continue_user_activity_with_type::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
+            );
+            decl.add_method(
+                sel!(application:continueUserActivity:restorationHandler:),
+                continue_user_activity::<T> as extern "C" fn(&Object, _, _, id, id) -> BOOL
+            );
+            decl.add_method(
+                sel!(application:didFailToContinueUserActivityWithType:error:),
+                failed_to_continue_user_activity::<T> as extern "C" fn(&Object, _, _, id, id)
+            );
+            decl.add_method(
+                sel!(application:didUpdateUserActivity:),
+                did_update_user_activity::<T> as extern "C" fn(&Object, _, _, id)
+            );
 
-        // Handling push notifications
-        decl.add_method(
-            sel!(application:didRegisterForRemoteNotificationsWithDeviceToken:),
-            registered_for_remote_notifications::<T> as extern "C" fn(&Object, _, _, id)
-        );
-        decl.add_method(
-            sel!(application:didFailToRegisterForRemoteNotificationsWithError:),
-            failed_to_register_for_remote_notifications::<T> as extern "C" fn(&Object, _, _, id)
-        );
-        decl.add_method(
-            sel!(application:didReceiveRemoteNotification:),
-            did_receive_remote_notification::<T> as extern "C" fn(&Object, _, _, id)
-        );
+            // Handling push notifications
+            decl.add_method(
+                sel!(application:didRegisterForRemoteNotificationsWithDeviceToken:),
+                registered_for_remote_notifications::<T> as extern "C" fn(&Object, _, _, id)
+            );
+            decl.add_method(
+                sel!(application:didFailToRegisterForRemoteNotificationsWithError:),
+                failed_to_register_for_remote_notifications::<T> as extern "C" fn(&Object, _, _, id)
+            );
+            decl.add_method(
+                sel!(application:didReceiveRemoteNotification:),
+                did_receive_remote_notification::<T> as extern "C" fn(&Object, _, _, id)
+            );
 
-        // CloudKit
-        #[cfg(feature = "cloudkit")]
-        decl.add_method(
-            sel!(application:userDidAcceptCloudKitShareWithMetadata:),
-            accepted_cloudkit_share::<T> as extern "C" fn(&Object, _, _, id)
-        );
+            // CloudKit
+            #[cfg(feature = "cloudkit")]
+            decl.add_method(
+                sel!(application:userDidAcceptCloudKitShareWithMetadata:),
+                accepted_cloudkit_share::<T> as extern "C" fn(&Object, _, _, id)
+            );
 
-        // Opening Files
-        decl.add_method(
-            sel!(application:openURLs:),
-            open_urls::<T> as extern "C" fn(&Object, _, _, id)
-        );
-        decl.add_method(
-            sel!(application:openFileWithoutUI:),
-            open_file_without_ui::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
-        );
-        decl.add_method(
-            sel!(applicationShouldOpenUntitledFile:),
-            should_open_untitled_file::<T> as extern "C" fn(&Object, _, _) -> BOOL
-        );
-        decl.add_method(
-            sel!(applicationOpenUntitledFile:),
-            open_untitled_file::<T> as extern "C" fn(&Object, _, _) -> BOOL
-        );
-        decl.add_method(
-            sel!(application:openTempFile:),
-            open_temp_file::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
-        );
+            // Opening Files
+            decl.add_method(
+                sel!(application:openURLs:),
+                open_urls::<T> as extern "C" fn(&Object, _, _, id)
+            );
+            decl.add_method(
+                sel!(application:openFileWithoutUI:),
+                open_file_without_ui::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
+            );
+            decl.add_method(
+                sel!(applicationShouldOpenUntitledFile:),
+                should_open_untitled_file::<T> as extern "C" fn(&Object, _, _) -> BOOL
+            );
+            decl.add_method(
+                sel!(applicationOpenUntitledFile:),
+                open_untitled_file::<T> as extern "C" fn(&Object, _, _) -> BOOL
+            );
+            decl.add_method(
+                sel!(application:openTempFile:),
+                open_temp_file::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
+            );
 
-        // Printing
-        decl.add_method(
-            sel!(application:printFile:),
-            print_file::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
-        );
-        decl.add_method(
-            sel!(application:printFiles:withSettings:showPrintPanels:),
-            print_files::<T> as extern "C" fn(&Object, _, id, id, id, BOOL) -> NSUInteger
-        );
+            // Printing
+            decl.add_method(
+                sel!(application:printFile:),
+                print_file::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
+            );
+            decl.add_method(
+                sel!(application:printFiles:withSettings:showPrintPanels:),
+                print_files::<T> as extern "C" fn(&Object, _, id, id, id, BOOL) -> NSUInteger
+            );
 
-        // @TODO: Restoring Application State
-        // Depends on NSCoder support, which is... welp.
+            // @TODO: Restoring Application State
+            // Depends on NSCoder support, which is... welp.
 
-        // Scripting
-        decl.add_method(
-            sel!(application:delegateHandlesKey:),
-            delegate_handles_key::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
-        );
+            // Scripting
+            decl.add_method(
+                sel!(application:delegateHandlesKey:),
+                delegate_handles_key::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
+            );
 
-        DELEGATE_CLASS = decl.register();
-    });
+            DELEGATE_CLASS = decl.register();
+        });
+    }
 
     unsafe { DELEGATE_CLASS }
 }

--- a/src/appkit/app/delegate.rs
+++ b/src/appkit/app/delegate.rs
@@ -3,24 +3,19 @@
 //! for potential future use.
 
 use std::ffi::c_void;
-use std::sync::Once;
 
 use block::Block;
-
-use objc::declare::ClassDecl;
 use objc::runtime::{Class, Object, Sel};
-use objc::{class, msg_send, sel, sel_impl};
-
+use objc::{msg_send, sel, sel_impl};
 use url::Url;
 
 use crate::appkit::app::{AppDelegate, APP_PTR};
 use crate::appkit::printing::PrintSettings;
-use crate::error::Error;
-use crate::foundation::{id, nil, to_bool, NSArray, NSString, NSUInteger, BOOL, NO, YES};
-use crate::user_activity::UserActivity;
-
 #[cfg(feature = "cloudkit")]
 use crate::cloudkit::share::CKShareMetaData;
+use crate::error::Error;
+use crate::foundation::{id, load_or_register_class, nil, to_bool, NSArray, NSString, NSUInteger, BOOL, NO, YES};
+use crate::user_activity::UserActivity;
 
 /// A handy method for grabbing our `AppDelegate` from the pointer. This is different from our
 /// standard `utils` version as this doesn't require `RefCell` backing.
@@ -295,180 +290,165 @@ extern "C" fn delegate_handles_key<T: AppDelegate>(this: &Object, _: Sel, _: id,
 /// Registers an `NSObject` application delegate, and configures it for the various callbacks and
 /// pointers we need to have.
 pub(crate) fn register_app_delegate_class<T: AppDelegate + AppDelegate>() -> *const Class {
-    static mut DELEGATE_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTAppDelegate";
+    load_or_register_class("NSObject", "RSTAppDelegate", |decl| unsafe {
+        decl.add_ivar::<usize>(APP_PTR);
 
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { DELEGATE_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(NSObject);
-            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+        // Launching Applications
+        decl.add_method(
+            sel!(applicationWillFinishLaunching:),
+            will_finish_launching::<T> as extern "C" fn(&Object, _, _)
+        );
+        decl.add_method(
+            sel!(applicationDidFinishLaunching:),
+            did_finish_launching::<T> as extern "C" fn(&Object, _, _)
+        );
 
-            decl.add_ivar::<usize>(APP_PTR);
+        // Managing Active Status
+        decl.add_method(
+            sel!(applicationWillBecomeActive:),
+            will_become_active::<T> as extern "C" fn(&Object, _, _)
+        );
+        decl.add_method(
+            sel!(applicationDidBecomeActive:),
+            did_become_active::<T> as extern "C" fn(&Object, _, _)
+        );
+        decl.add_method(
+            sel!(applicationWillResignActive:),
+            will_resign_active::<T> as extern "C" fn(&Object, _, _)
+        );
+        decl.add_method(
+            sel!(applicationDidResignActive:),
+            did_resign_active::<T> as extern "C" fn(&Object, _, _)
+        );
 
-            // Launching Applications
-            decl.add_method(
-                sel!(applicationWillFinishLaunching:),
-                will_finish_launching::<T> as extern "C" fn(&Object, _, _)
-            );
-            decl.add_method(
-                sel!(applicationDidFinishLaunching:),
-                did_finish_launching::<T> as extern "C" fn(&Object, _, _)
-            );
+        // Terminating Applications
+        decl.add_method(
+            sel!(applicationShouldTerminate:),
+            should_terminate::<T> as extern "C" fn(&Object, _, _) -> NSUInteger
+        );
+        decl.add_method(
+            sel!(applicationWillTerminate:),
+            will_terminate::<T> as extern "C" fn(&Object, _, _)
+        );
+        decl.add_method(
+            sel!(applicationShouldTerminateAfterLastWindowClosed:),
+            should_terminate_after_last_window_closed::<T> as extern "C" fn(&Object, _, _) -> BOOL
+        );
 
-            // Managing Active Status
-            decl.add_method(
-                sel!(applicationWillBecomeActive:),
-                will_become_active::<T> as extern "C" fn(&Object, _, _)
-            );
-            decl.add_method(
-                sel!(applicationDidBecomeActive:),
-                did_become_active::<T> as extern "C" fn(&Object, _, _)
-            );
-            decl.add_method(
-                sel!(applicationWillResignActive:),
-                will_resign_active::<T> as extern "C" fn(&Object, _, _)
-            );
-            decl.add_method(
-                sel!(applicationDidResignActive:),
-                did_resign_active::<T> as extern "C" fn(&Object, _, _)
-            );
+        // Hiding Applications
+        decl.add_method(sel!(applicationWillHide:), will_hide::<T> as extern "C" fn(&Object, _, _));
+        decl.add_method(sel!(applicationDidHide:), did_hide::<T> as extern "C" fn(&Object, _, _));
+        decl.add_method(sel!(applicationWillUnhide:), will_unhide::<T> as extern "C" fn(&Object, _, _));
+        decl.add_method(sel!(applicationDidUnhide:), did_unhide::<T> as extern "C" fn(&Object, _, _));
 
-            // Terminating Applications
-            decl.add_method(
-                sel!(applicationShouldTerminate:),
-                should_terminate::<T> as extern "C" fn(&Object, _, _) -> NSUInteger
-            );
-            decl.add_method(
-                sel!(applicationWillTerminate:),
-                will_terminate::<T> as extern "C" fn(&Object, _, _)
-            );
-            decl.add_method(
-                sel!(applicationShouldTerminateAfterLastWindowClosed:),
-                should_terminate_after_last_window_closed::<T> as extern "C" fn(&Object, _, _) -> BOOL
-            );
+        // Managing Windows
+        decl.add_method(sel!(applicationWillUpdate:), will_update::<T> as extern "C" fn(&Object, _, _));
+        decl.add_method(sel!(applicationDidUpdate:), did_update::<T> as extern "C" fn(&Object, _, _));
+        decl.add_method(
+            sel!(applicationShouldHandleReopen:hasVisibleWindows:),
+            should_handle_reopen::<T> as extern "C" fn(&Object, _, _, BOOL) -> BOOL
+        );
 
-            // Hiding Applications
-            decl.add_method(sel!(applicationWillHide:), will_hide::<T> as extern "C" fn(&Object, _, _));
-            decl.add_method(sel!(applicationDidHide:), did_hide::<T> as extern "C" fn(&Object, _, _));
-            decl.add_method(sel!(applicationWillUnhide:), will_unhide::<T> as extern "C" fn(&Object, _, _));
-            decl.add_method(sel!(applicationDidUnhide:), did_unhide::<T> as extern "C" fn(&Object, _, _));
+        // Dock Menu
+        decl.add_method(
+            sel!(applicationDockMenu:),
+            dock_menu::<T> as extern "C" fn(&Object, _, _) -> id
+        );
 
-            // Managing Windows
-            decl.add_method(sel!(applicationWillUpdate:), will_update::<T> as extern "C" fn(&Object, _, _));
-            decl.add_method(sel!(applicationDidUpdate:), did_update::<T> as extern "C" fn(&Object, _, _));
-            decl.add_method(
-                sel!(applicationShouldHandleReopen:hasVisibleWindows:),
-                should_handle_reopen::<T> as extern "C" fn(&Object, _, _, BOOL) -> BOOL
-            );
+        // Displaying Errors
+        decl.add_method(
+            sel!(application:willPresentError:),
+            will_present_error::<T> as extern "C" fn(&Object, _, _, id) -> id
+        );
 
-            // Dock Menu
-            decl.add_method(
-                sel!(applicationDockMenu:),
-                dock_menu::<T> as extern "C" fn(&Object, _, _) -> id
-            );
+        // Managing the Screen
+        decl.add_method(
+            sel!(applicationDidChangeScreenParameters:),
+            did_change_screen_parameters::<T> as extern "C" fn(&Object, _, _)
+        );
+        decl.add_method(
+            sel!(applicationDidChangeOcclusionState:),
+            did_change_occlusion_state::<T> as extern "C" fn(&Object, _, _)
+        );
 
-            // Displaying Errors
-            decl.add_method(
-                sel!(application:willPresentError:),
-                will_present_error::<T> as extern "C" fn(&Object, _, _, id) -> id
-            );
+        // User Activities
+        decl.add_method(
+            sel!(application:willContinueUserActivityWithType:),
+            will_continue_user_activity_with_type::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
+        );
+        decl.add_method(
+            sel!(application:continueUserActivity:restorationHandler:),
+            continue_user_activity::<T> as extern "C" fn(&Object, _, _, id, id) -> BOOL
+        );
+        decl.add_method(
+            sel!(application:didFailToContinueUserActivityWithType:error:),
+            failed_to_continue_user_activity::<T> as extern "C" fn(&Object, _, _, id, id)
+        );
+        decl.add_method(
+            sel!(application:didUpdateUserActivity:),
+            did_update_user_activity::<T> as extern "C" fn(&Object, _, _, id)
+        );
 
-            // Managing the Screen
-            decl.add_method(
-                sel!(applicationDidChangeScreenParameters:),
-                did_change_screen_parameters::<T> as extern "C" fn(&Object, _, _)
-            );
-            decl.add_method(
-                sel!(applicationDidChangeOcclusionState:),
-                did_change_occlusion_state::<T> as extern "C" fn(&Object, _, _)
-            );
+        // Handling push notifications
+        decl.add_method(
+            sel!(application:didRegisterForRemoteNotificationsWithDeviceToken:),
+            registered_for_remote_notifications::<T> as extern "C" fn(&Object, _, _, id)
+        );
+        decl.add_method(
+            sel!(application:didFailToRegisterForRemoteNotificationsWithError:),
+            failed_to_register_for_remote_notifications::<T> as extern "C" fn(&Object, _, _, id)
+        );
+        decl.add_method(
+            sel!(application:didReceiveRemoteNotification:),
+            did_receive_remote_notification::<T> as extern "C" fn(&Object, _, _, id)
+        );
 
-            // User Activities
-            decl.add_method(
-                sel!(application:willContinueUserActivityWithType:),
-                will_continue_user_activity_with_type::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
-            );
-            decl.add_method(
-                sel!(application:continueUserActivity:restorationHandler:),
-                continue_user_activity::<T> as extern "C" fn(&Object, _, _, id, id) -> BOOL
-            );
-            decl.add_method(
-                sel!(application:didFailToContinueUserActivityWithType:error:),
-                failed_to_continue_user_activity::<T> as extern "C" fn(&Object, _, _, id, id)
-            );
-            decl.add_method(
-                sel!(application:didUpdateUserActivity:),
-                did_update_user_activity::<T> as extern "C" fn(&Object, _, _, id)
-            );
+        // CloudKit
+        #[cfg(feature = "cloudkit")]
+        decl.add_method(
+            sel!(application:userDidAcceptCloudKitShareWithMetadata:),
+            accepted_cloudkit_share::<T> as extern "C" fn(&Object, _, _, id)
+        );
 
-            // Handling push notifications
-            decl.add_method(
-                sel!(application:didRegisterForRemoteNotificationsWithDeviceToken:),
-                registered_for_remote_notifications::<T> as extern "C" fn(&Object, _, _, id)
-            );
-            decl.add_method(
-                sel!(application:didFailToRegisterForRemoteNotificationsWithError:),
-                failed_to_register_for_remote_notifications::<T> as extern "C" fn(&Object, _, _, id)
-            );
-            decl.add_method(
-                sel!(application:didReceiveRemoteNotification:),
-                did_receive_remote_notification::<T> as extern "C" fn(&Object, _, _, id)
-            );
+        // Opening Files
+        decl.add_method(
+            sel!(application:openURLs:),
+            open_urls::<T> as extern "C" fn(&Object, _, _, id)
+        );
+        decl.add_method(
+            sel!(application:openFileWithoutUI:),
+            open_file_without_ui::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
+        );
+        decl.add_method(
+            sel!(applicationShouldOpenUntitledFile:),
+            should_open_untitled_file::<T> as extern "C" fn(&Object, _, _) -> BOOL
+        );
+        decl.add_method(
+            sel!(applicationOpenUntitledFile:),
+            open_untitled_file::<T> as extern "C" fn(&Object, _, _) -> BOOL
+        );
+        decl.add_method(
+            sel!(application:openTempFile:),
+            open_temp_file::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
+        );
 
-            // CloudKit
-            #[cfg(feature = "cloudkit")]
-            decl.add_method(
-                sel!(application:userDidAcceptCloudKitShareWithMetadata:),
-                accepted_cloudkit_share::<T> as extern "C" fn(&Object, _, _, id)
-            );
+        // Printing
+        decl.add_method(
+            sel!(application:printFile:),
+            print_file::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
+        );
+        decl.add_method(
+            sel!(application:printFiles:withSettings:showPrintPanels:),
+            print_files::<T> as extern "C" fn(&Object, _, id, id, id, BOOL) -> NSUInteger
+        );
 
-            // Opening Files
-            decl.add_method(
-                sel!(application:openURLs:),
-                open_urls::<T> as extern "C" fn(&Object, _, _, id)
-            );
-            decl.add_method(
-                sel!(application:openFileWithoutUI:),
-                open_file_without_ui::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
-            );
-            decl.add_method(
-                sel!(applicationShouldOpenUntitledFile:),
-                should_open_untitled_file::<T> as extern "C" fn(&Object, _, _) -> BOOL
-            );
-            decl.add_method(
-                sel!(applicationOpenUntitledFile:),
-                open_untitled_file::<T> as extern "C" fn(&Object, _, _) -> BOOL
-            );
-            decl.add_method(
-                sel!(application:openTempFile:),
-                open_temp_file::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
-            );
+        // @TODO: Restoring Application State
+        // Depends on NSCoder support, which is... welp.
 
-            // Printing
-            decl.add_method(
-                sel!(application:printFile:),
-                print_file::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
-            );
-            decl.add_method(
-                sel!(application:printFiles:withSettings:showPrintPanels:),
-                print_files::<T> as extern "C" fn(&Object, _, id, id, id, BOOL) -> NSUInteger
-            );
-
-            // @TODO: Restoring Application State
-            // Depends on NSCoder support, which is... welp.
-
-            // Scripting
-            decl.add_method(
-                sel!(application:delegateHandlesKey:),
-                delegate_handles_key::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
-            );
-
-            DELEGATE_CLASS = decl.register();
-        });
-    }
-
-    unsafe { DELEGATE_CLASS }
+        // Scripting
+        decl.add_method(
+            sel!(application:delegateHandlesKey:),
+            delegate_handles_key::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
+        );
+    })
 }

--- a/src/appkit/menu/item.rs
+++ b/src/appkit/menu/item.rs
@@ -3,16 +3,13 @@
 //! now.
 
 use std::fmt;
-use std::sync::Once;
 
-use block::ConcreteBlock;
-use objc::declare::ClassDecl;
 use objc::runtime::{Class, Object, Sel};
 use objc::{class, msg_send, sel, sel_impl};
 use objc_id::Id;
 
 use crate::events::EventModifierFlag;
-use crate::foundation::{id, nil, NSString, NSUInteger};
+use crate::foundation::{id, load_or_register_class, NSString, NSUInteger};
 
 static BLOCK_PTR: &'static str = "cacaoMenuItemBlockPtr";
 
@@ -314,24 +311,10 @@ extern "C" fn fire_block_action(this: &Object, _: Sel, _item: id) {
 /// In general, we do not want to do more than we need to here - menus are one of the last areas
 /// where Carbon still lurks, and subclassing things can get weird.
 pub(crate) fn register_menu_item_class() -> *const Class {
-    static mut APP_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "CacaoMenuItem";
+    load_or_register_class("NSMenuItem", "CacaoMenuItem", |decl| unsafe {
+        decl.add_ivar::<usize>(BLOCK_PTR);
 
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { APP_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(NSMenuItem);
-            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-            decl.add_ivar::<usize>(BLOCK_PTR);
-
-            decl.add_method(sel!(dealloc), dealloc_cacao_menuitem as extern "C" fn(&Object, _));
-            decl.add_method(sel!(fireBlockAction:), fire_block_action as extern "C" fn(&Object, _, id));
-
-            APP_CLASS = decl.register();
-        });
-    }
-
-    unsafe { APP_CLASS }
+        decl.add_method(sel!(dealloc), dealloc_cacao_menuitem as extern "C" fn(&Object, _));
+        decl.add_method(sel!(fireBlockAction:), fire_block_action as extern "C" fn(&Object, _, id));
+    })
 }

--- a/src/appkit/menu/item.rs
+++ b/src/appkit/menu/item.rs
@@ -316,17 +316,22 @@ extern "C" fn fire_block_action(this: &Object, _: Sel, _item: id) {
 pub(crate) fn register_menu_item_class() -> *const Class {
     static mut APP_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "CacaoMenuItem";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSMenuItem);
-        let mut decl = ClassDecl::new("CacaoMenuItem", superclass).unwrap();
-        decl.add_ivar::<usize>(BLOCK_PTR);
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { APP_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSMenuItem);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            decl.add_ivar::<usize>(BLOCK_PTR);
 
-        decl.add_method(sel!(dealloc), dealloc_cacao_menuitem as extern "C" fn(&Object, _));
-        decl.add_method(sel!(fireBlockAction:), fire_block_action as extern "C" fn(&Object, _, id));
+            decl.add_method(sel!(dealloc), dealloc_cacao_menuitem as extern "C" fn(&Object, _));
+            decl.add_method(sel!(fireBlockAction:), fire_block_action as extern "C" fn(&Object, _, id));
 
-        APP_CLASS = decl.register();
-    });
+            APP_CLASS = decl.register();
+        });
+    }
 
     unsafe { APP_CLASS }
 }

--- a/src/appkit/window/controller/class.rs
+++ b/src/appkit/window/controller/class.rs
@@ -1,31 +1,15 @@
 //! Everything useful for the `WindowController`. Handles injecting an `NSWindowController` subclass
 //! into the Objective C runtime, which loops back to give us lifecycle methods.
 
-use std::sync::Once;
-
-use objc::class;
-use objc::declare::ClassDecl;
 use objc::runtime::Class;
 
 use crate::appkit::window::{WindowDelegate, WINDOW_DELEGATE_PTR};
+use crate::foundation::load_or_register_class;
 
 /// Injects an `NSWindowController` subclass, with some callback and pointer ivars for what we
 /// need to do.
 pub(crate) fn register_window_controller_class<T: WindowDelegate>() -> *const Class {
-    static mut DELEGATE_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTWindowController";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { DELEGATE_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(NSWindowController);
-            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-            decl.add_ivar::<usize>(WINDOW_DELEGATE_PTR);
-            DELEGATE_CLASS = decl.register();
-        });
-    }
-
-    unsafe { DELEGATE_CLASS }
+    load_or_register_class("NSWindowController", "RSTWindowController", |decl| unsafe {
+        decl.add_ivar::<usize>(WINDOW_DELEGATE_PTR);
+    })
 }

--- a/src/appkit/window/controller/class.rs
+++ b/src/appkit/window/controller/class.rs
@@ -14,13 +14,18 @@ use crate::appkit::window::{WindowDelegate, WINDOW_DELEGATE_PTR};
 pub(crate) fn register_window_controller_class<T: WindowDelegate>() -> *const Class {
     static mut DELEGATE_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTWindowController";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSWindowController);
-        let mut decl = ClassDecl::new("RSTWindowController", superclass).unwrap();
-        decl.add_ivar::<usize>(WINDOW_DELEGATE_PTR);
-        DELEGATE_CLASS = decl.register();
-    });
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { DELEGATE_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSWindowController);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            decl.add_ivar::<usize>(WINDOW_DELEGATE_PTR);
+            DELEGATE_CLASS = decl.register();
+        });
+    }
 
     unsafe { DELEGATE_CLASS }
 }

--- a/src/appkit/window/mod.rs
+++ b/src/appkit/window/mod.rs
@@ -110,14 +110,14 @@ impl Window {
 
         Window {
             objc: objc,
-            delegate: None,
+            delegate: None
         }
     }
 
     pub(crate) unsafe fn existing(window: *mut Object) -> Window {
         Window {
             objc: ShareId::from_ptr(window),
-            delegate: None,
+            delegate: None
         }
     }
 }

--- a/src/button/mod.rs
+++ b/src/button/mod.rs
@@ -345,12 +345,18 @@ impl Drop for Button {
 fn register_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTButton";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSButton);
-        let decl = ClassDecl::new("RSTButton", superclass).unwrap();
-        VIEW_CLASS = decl.register();
-    });
-
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe {
+            VIEW_CLASS = c;
+        }
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSButton);
+            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            VIEW_CLASS = decl.register();
+        });
+    }
     unsafe { VIEW_CLASS }
 }

--- a/src/button/mod.rs
+++ b/src/button/mod.rs
@@ -305,6 +305,7 @@ impl ObjcAccess for Button {
 }
 
 impl Layout for Button {}
+
 impl Control for Button {}
 
 impl ObjcAccess for &Button {
@@ -318,6 +319,7 @@ impl ObjcAccess for &Button {
 }
 
 impl Layout for &Button {}
+
 impl Control for &Button {}
 
 impl Drop for Button {

--- a/src/color/appkit_dynamic_color.rs
+++ b/src/color/appkit_dynamic_color.rs
@@ -261,107 +261,112 @@ extern "C" fn color_with_system_effect(this: &Object, _: Sel, effect: NSInteger)
 pub(crate) fn register_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "CacaoDynamicColor";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSColor);
-        let mut decl = ClassDecl::new("CacaoDynamicColor", superclass).unwrap();
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSColor);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
 
-        // These methods all need to be forwarded, so let's hook them up.
-        decl.add_method(sel!(colorSpace), color_space as extern "C" fn(&Object, _) -> id);
-        decl.add_method(
-            sel!(colorUsingColorSpace:),
-            color_using_color_space as extern "C" fn(&Object, _, id) -> id
-        );
-        decl.add_method(sel!(colorSpaceName), color_space_name as extern "C" fn(&Object, _) -> id);
-        decl.add_method(
-            sel!(colorUsingColorSpaceName:),
-            color_using_color_space_name as extern "C" fn(&Object, _, id) -> id
-        );
-        decl.add_method(
-            sel!(numberOfComponents),
-            number_of_components as extern "C" fn(&Object, _) -> NSInteger
-        );
+            // These methods all need to be forwarded, so let's hook them up.
+            decl.add_method(sel!(colorSpace), color_space as extern "C" fn(&Object, _) -> id);
+            decl.add_method(
+                sel!(colorUsingColorSpace:),
+                color_using_color_space as extern "C" fn(&Object, _, id) -> id
+            );
+            decl.add_method(sel!(colorSpaceName), color_space_name as extern "C" fn(&Object, _) -> id);
+            decl.add_method(
+                sel!(colorUsingColorSpaceName:),
+                color_using_color_space_name as extern "C" fn(&Object, _, id) -> id
+            );
+            decl.add_method(
+                sel!(numberOfComponents),
+                number_of_components as extern "C" fn(&Object, _) -> NSInteger
+            );
 
-        decl.add_method(sel!(getComponents:), get_components as extern "C" fn(&Object, _, CGFloat));
-        decl.add_method(
-            sel!(getRed:green:blue:alpha:),
-            get_rgba as extern "C" fn(&Object, _, CGFloat, CGFloat, CGFloat, CGFloat)
-        );
-        decl.add_method(sel!(redComponent), red_component as extern "C" fn(&Object, _) -> CGFloat);
-        decl.add_method(sel!(greenComponent), green_component as extern "C" fn(&Object, _) -> CGFloat);
-        decl.add_method(sel!(blueComponent), blue_component as extern "C" fn(&Object, _) -> CGFloat);
+            decl.add_method(sel!(getComponents:), get_components as extern "C" fn(&Object, _, CGFloat));
+            decl.add_method(
+                sel!(getRed:green:blue:alpha:),
+                get_rgba as extern "C" fn(&Object, _, CGFloat, CGFloat, CGFloat, CGFloat)
+            );
+            decl.add_method(sel!(redComponent), red_component as extern "C" fn(&Object, _) -> CGFloat);
+            decl.add_method(sel!(greenComponent), green_component as extern "C" fn(&Object, _) -> CGFloat);
+            decl.add_method(sel!(blueComponent), blue_component as extern "C" fn(&Object, _) -> CGFloat);
 
-        decl.add_method(sel!(hueComponent), hue_component as extern "C" fn(&Object, _) -> CGFloat);
-        decl.add_method(
-            sel!(saturationComponent),
-            saturation_component as extern "C" fn(&Object, _) -> CGFloat
-        );
-        decl.add_method(
-            sel!(brightnessComponent),
-            brightness_component as extern "C" fn(&Object, _) -> CGFloat
-        );
-        decl.add_method(
-            sel!(getHue:saturation:brightness:alpha:),
-            get_hsba as extern "C" fn(&Object, _, CGFloat, CGFloat, CGFloat, CGFloat)
-        );
+            decl.add_method(sel!(hueComponent), hue_component as extern "C" fn(&Object, _) -> CGFloat);
+            decl.add_method(
+                sel!(saturationComponent),
+                saturation_component as extern "C" fn(&Object, _) -> CGFloat
+            );
+            decl.add_method(
+                sel!(brightnessComponent),
+                brightness_component as extern "C" fn(&Object, _) -> CGFloat
+            );
+            decl.add_method(
+                sel!(getHue:saturation:brightness:alpha:),
+                get_hsba as extern "C" fn(&Object, _, CGFloat, CGFloat, CGFloat, CGFloat)
+            );
 
-        decl.add_method(sel!(whiteComponent), white_component as extern "C" fn(&Object, _) -> CGFloat);
-        decl.add_method(
-            sel!(getWhite:alpha:),
-            get_white as extern "C" fn(&Object, _, CGFloat, CGFloat)
-        );
+            decl.add_method(sel!(whiteComponent), white_component as extern "C" fn(&Object, _) -> CGFloat);
+            decl.add_method(
+                sel!(getWhite:alpha:),
+                get_white as extern "C" fn(&Object, _, CGFloat, CGFloat)
+            );
 
-        decl.add_method(sel!(cyanComponent), cyan_component as extern "C" fn(&Object, _) -> CGFloat);
-        decl.add_method(
-            sel!(magentaComponent),
-            magenta_component as extern "C" fn(&Object, _) -> CGFloat
-        );
-        decl.add_method(
-            sel!(yellowComponent),
-            yellow_component as extern "C" fn(&Object, _) -> CGFloat
-        );
-        decl.add_method(sel!(blackComponent), black_component as extern "C" fn(&Object, _) -> CGFloat);
-        decl.add_method(
-            sel!(getCyan:magenta:yellow:black:alpha:),
-            get_cmyk as extern "C" fn(&Object, _, CGFloat, CGFloat, CGFloat, CGFloat, CGFloat)
-        );
+            decl.add_method(sel!(cyanComponent), cyan_component as extern "C" fn(&Object, _) -> CGFloat);
+            decl.add_method(
+                sel!(magentaComponent),
+                magenta_component as extern "C" fn(&Object, _) -> CGFloat
+            );
+            decl.add_method(
+                sel!(yellowComponent),
+                yellow_component as extern "C" fn(&Object, _) -> CGFloat
+            );
+            decl.add_method(sel!(blackComponent), black_component as extern "C" fn(&Object, _) -> CGFloat);
+            decl.add_method(
+                sel!(getCyan:magenta:yellow:black:alpha:),
+                get_cmyk as extern "C" fn(&Object, _, CGFloat, CGFloat, CGFloat, CGFloat, CGFloat)
+            );
 
-        decl.add_method(sel!(alphaComponent), alpha_component as extern "C" fn(&Object, _) -> CGFloat);
+            decl.add_method(sel!(alphaComponent), alpha_component as extern "C" fn(&Object, _) -> CGFloat);
 
-        decl.add_method(sel!(CGColor), cg_color as extern "C" fn(&Object, _) -> id);
-        decl.add_method(sel!(setStroke), set_stroke as extern "C" fn(&Object, _));
-        decl.add_method(sel!(setFill), set_fill as extern "C" fn(&Object, _));
-        decl.add_method(sel!(set), call_set as extern "C" fn(&Object, _));
+            decl.add_method(sel!(CGColor), cg_color as extern "C" fn(&Object, _) -> id);
+            decl.add_method(sel!(setStroke), set_stroke as extern "C" fn(&Object, _));
+            decl.add_method(sel!(setFill), set_fill as extern "C" fn(&Object, _));
+            decl.add_method(sel!(set), call_set as extern "C" fn(&Object, _));
 
-        decl.add_method(
-            sel!(highlightWithLevel:),
-            highlight_with_level as extern "C" fn(&Object, _, CGFloat) -> id
-        );
-        decl.add_method(
-            sel!(shadowWithLevel:),
-            shadow_with_level as extern "C" fn(&Object, _, CGFloat) -> id
-        );
+            decl.add_method(
+                sel!(highlightWithLevel:),
+                highlight_with_level as extern "C" fn(&Object, _, CGFloat) -> id
+            );
+            decl.add_method(
+                sel!(shadowWithLevel:),
+                shadow_with_level as extern "C" fn(&Object, _, CGFloat) -> id
+            );
 
-        decl.add_method(
-            sel!(colorWithAlphaComponent:),
-            color_with_alpha_component as extern "C" fn(&Object, _, CGFloat) -> id
-        );
-        decl.add_method(
-            sel!(blendedColorWithFraction:ofColor:),
-            blended_color as extern "C" fn(&Object, _, CGFloat, id) -> id
-        );
-        decl.add_method(
-            sel!(colorWithSystemEffect:),
-            color_with_system_effect as extern "C" fn(&Object, _, NSInteger) -> id
-        );
+            decl.add_method(
+                sel!(colorWithAlphaComponent:),
+                color_with_alpha_component as extern "C" fn(&Object, _, CGFloat) -> id
+            );
+            decl.add_method(
+                sel!(blendedColorWithFraction:ofColor:),
+                blended_color as extern "C" fn(&Object, _, CGFloat, id) -> id
+            );
+            decl.add_method(
+                sel!(colorWithSystemEffect:),
+                color_with_system_effect as extern "C" fn(&Object, _, NSInteger) -> id
+            );
 
-        decl.add_ivar::<id>(AQUA_LIGHT_COLOR_NORMAL_CONTRAST);
-        decl.add_ivar::<id>(AQUA_LIGHT_COLOR_HIGH_CONTRAST);
-        decl.add_ivar::<id>(AQUA_DARK_COLOR_NORMAL_CONTRAST);
-        decl.add_ivar::<id>(AQUA_DARK_COLOR_HIGH_CONTRAST);
+            decl.add_ivar::<id>(AQUA_LIGHT_COLOR_NORMAL_CONTRAST);
+            decl.add_ivar::<id>(AQUA_LIGHT_COLOR_HIGH_CONTRAST);
+            decl.add_ivar::<id>(AQUA_DARK_COLOR_NORMAL_CONTRAST);
+            decl.add_ivar::<id>(AQUA_DARK_COLOR_HIGH_CONTRAST);
 
-        VIEW_CLASS = decl.register();
-    });
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }

--- a/src/color/appkit_dynamic_color.rs
+++ b/src/color/appkit_dynamic_color.rs
@@ -10,16 +10,11 @@
 //! that enables this functionality, we want to be able to provide this with some level of
 //! backwards compatibility for Mojave, as that's still a supported OS.
 
-use std::os::raw::c_void;
-use std::sync::Once;
-
 use core_graphics::base::CGFloat;
-
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel, BOOL};
+use objc::runtime::{Class, Object, Sel};
 use objc::{class, msg_send, sel, sel_impl};
 
-use crate::foundation::{id, nil, NSArray, NSInteger, NSString, NSUInteger, NO, YES};
+use crate::foundation::{id, load_or_register_class, nil, NSArray, NSInteger};
 use crate::utils::os;
 
 pub(crate) const AQUA_LIGHT_COLOR_NORMAL_CONTRAST: &'static str = "AQUA_LIGHT_COLOR_NORMAL_CONTRAST";
@@ -259,114 +254,99 @@ extern "C" fn color_with_system_effect(this: &Object, _: Sel, effect: NSInteger)
 }
 
 pub(crate) fn register_class() -> *const Class {
-    static mut VIEW_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "CacaoDynamicColor";
+    load_or_register_class("NSColor", "CacaoDynamicColor", |decl| unsafe {
+        // These methods all need to be forwarded, so let's hook them up.
+        decl.add_method(sel!(colorSpace), color_space as extern "C" fn(&Object, _) -> id);
+        decl.add_method(
+            sel!(colorUsingColorSpace:),
+            color_using_color_space as extern "C" fn(&Object, _, id) -> id
+        );
+        decl.add_method(sel!(colorSpaceName), color_space_name as extern "C" fn(&Object, _) -> id);
+        decl.add_method(
+            sel!(colorUsingColorSpaceName:),
+            color_using_color_space_name as extern "C" fn(&Object, _, id) -> id
+        );
+        decl.add_method(
+            sel!(numberOfComponents),
+            number_of_components as extern "C" fn(&Object, _) -> NSInteger
+        );
 
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { VIEW_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(NSColor);
-            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+        decl.add_method(sel!(getComponents:), get_components as extern "C" fn(&Object, _, CGFloat));
+        decl.add_method(
+            sel!(getRed:green:blue:alpha:),
+            get_rgba as extern "C" fn(&Object, _, CGFloat, CGFloat, CGFloat, CGFloat)
+        );
+        decl.add_method(sel!(redComponent), red_component as extern "C" fn(&Object, _) -> CGFloat);
+        decl.add_method(sel!(greenComponent), green_component as extern "C" fn(&Object, _) -> CGFloat);
+        decl.add_method(sel!(blueComponent), blue_component as extern "C" fn(&Object, _) -> CGFloat);
 
-            // These methods all need to be forwarded, so let's hook them up.
-            decl.add_method(sel!(colorSpace), color_space as extern "C" fn(&Object, _) -> id);
-            decl.add_method(
-                sel!(colorUsingColorSpace:),
-                color_using_color_space as extern "C" fn(&Object, _, id) -> id
-            );
-            decl.add_method(sel!(colorSpaceName), color_space_name as extern "C" fn(&Object, _) -> id);
-            decl.add_method(
-                sel!(colorUsingColorSpaceName:),
-                color_using_color_space_name as extern "C" fn(&Object, _, id) -> id
-            );
-            decl.add_method(
-                sel!(numberOfComponents),
-                number_of_components as extern "C" fn(&Object, _) -> NSInteger
-            );
+        decl.add_method(sel!(hueComponent), hue_component as extern "C" fn(&Object, _) -> CGFloat);
+        decl.add_method(
+            sel!(saturationComponent),
+            saturation_component as extern "C" fn(&Object, _) -> CGFloat
+        );
+        decl.add_method(
+            sel!(brightnessComponent),
+            brightness_component as extern "C" fn(&Object, _) -> CGFloat
+        );
+        decl.add_method(
+            sel!(getHue:saturation:brightness:alpha:),
+            get_hsba as extern "C" fn(&Object, _, CGFloat, CGFloat, CGFloat, CGFloat)
+        );
 
-            decl.add_method(sel!(getComponents:), get_components as extern "C" fn(&Object, _, CGFloat));
-            decl.add_method(
-                sel!(getRed:green:blue:alpha:),
-                get_rgba as extern "C" fn(&Object, _, CGFloat, CGFloat, CGFloat, CGFloat)
-            );
-            decl.add_method(sel!(redComponent), red_component as extern "C" fn(&Object, _) -> CGFloat);
-            decl.add_method(sel!(greenComponent), green_component as extern "C" fn(&Object, _) -> CGFloat);
-            decl.add_method(sel!(blueComponent), blue_component as extern "C" fn(&Object, _) -> CGFloat);
+        decl.add_method(sel!(whiteComponent), white_component as extern "C" fn(&Object, _) -> CGFloat);
+        decl.add_method(
+            sel!(getWhite:alpha:),
+            get_white as extern "C" fn(&Object, _, CGFloat, CGFloat)
+        );
 
-            decl.add_method(sel!(hueComponent), hue_component as extern "C" fn(&Object, _) -> CGFloat);
-            decl.add_method(
-                sel!(saturationComponent),
-                saturation_component as extern "C" fn(&Object, _) -> CGFloat
-            );
-            decl.add_method(
-                sel!(brightnessComponent),
-                brightness_component as extern "C" fn(&Object, _) -> CGFloat
-            );
-            decl.add_method(
-                sel!(getHue:saturation:brightness:alpha:),
-                get_hsba as extern "C" fn(&Object, _, CGFloat, CGFloat, CGFloat, CGFloat)
-            );
+        decl.add_method(sel!(cyanComponent), cyan_component as extern "C" fn(&Object, _) -> CGFloat);
+        decl.add_method(
+            sel!(magentaComponent),
+            magenta_component as extern "C" fn(&Object, _) -> CGFloat
+        );
+        decl.add_method(
+            sel!(yellowComponent),
+            yellow_component as extern "C" fn(&Object, _) -> CGFloat
+        );
+        decl.add_method(sel!(blackComponent), black_component as extern "C" fn(&Object, _) -> CGFloat);
+        decl.add_method(
+            sel!(getCyan:magenta:yellow:black:alpha:),
+            get_cmyk as extern "C" fn(&Object, _, CGFloat, CGFloat, CGFloat, CGFloat, CGFloat)
+        );
 
-            decl.add_method(sel!(whiteComponent), white_component as extern "C" fn(&Object, _) -> CGFloat);
-            decl.add_method(
-                sel!(getWhite:alpha:),
-                get_white as extern "C" fn(&Object, _, CGFloat, CGFloat)
-            );
+        decl.add_method(sel!(alphaComponent), alpha_component as extern "C" fn(&Object, _) -> CGFloat);
 
-            decl.add_method(sel!(cyanComponent), cyan_component as extern "C" fn(&Object, _) -> CGFloat);
-            decl.add_method(
-                sel!(magentaComponent),
-                magenta_component as extern "C" fn(&Object, _) -> CGFloat
-            );
-            decl.add_method(
-                sel!(yellowComponent),
-                yellow_component as extern "C" fn(&Object, _) -> CGFloat
-            );
-            decl.add_method(sel!(blackComponent), black_component as extern "C" fn(&Object, _) -> CGFloat);
-            decl.add_method(
-                sel!(getCyan:magenta:yellow:black:alpha:),
-                get_cmyk as extern "C" fn(&Object, _, CGFloat, CGFloat, CGFloat, CGFloat, CGFloat)
-            );
+        decl.add_method(sel!(CGColor), cg_color as extern "C" fn(&Object, _) -> id);
+        decl.add_method(sel!(setStroke), set_stroke as extern "C" fn(&Object, _));
+        decl.add_method(sel!(setFill), set_fill as extern "C" fn(&Object, _));
+        decl.add_method(sel!(set), call_set as extern "C" fn(&Object, _));
 
-            decl.add_method(sel!(alphaComponent), alpha_component as extern "C" fn(&Object, _) -> CGFloat);
+        decl.add_method(
+            sel!(highlightWithLevel:),
+            highlight_with_level as extern "C" fn(&Object, _, CGFloat) -> id
+        );
+        decl.add_method(
+            sel!(shadowWithLevel:),
+            shadow_with_level as extern "C" fn(&Object, _, CGFloat) -> id
+        );
 
-            decl.add_method(sel!(CGColor), cg_color as extern "C" fn(&Object, _) -> id);
-            decl.add_method(sel!(setStroke), set_stroke as extern "C" fn(&Object, _));
-            decl.add_method(sel!(setFill), set_fill as extern "C" fn(&Object, _));
-            decl.add_method(sel!(set), call_set as extern "C" fn(&Object, _));
+        decl.add_method(
+            sel!(colorWithAlphaComponent:),
+            color_with_alpha_component as extern "C" fn(&Object, _, CGFloat) -> id
+        );
+        decl.add_method(
+            sel!(blendedColorWithFraction:ofColor:),
+            blended_color as extern "C" fn(&Object, _, CGFloat, id) -> id
+        );
+        decl.add_method(
+            sel!(colorWithSystemEffect:),
+            color_with_system_effect as extern "C" fn(&Object, _, NSInteger) -> id
+        );
 
-            decl.add_method(
-                sel!(highlightWithLevel:),
-                highlight_with_level as extern "C" fn(&Object, _, CGFloat) -> id
-            );
-            decl.add_method(
-                sel!(shadowWithLevel:),
-                shadow_with_level as extern "C" fn(&Object, _, CGFloat) -> id
-            );
-
-            decl.add_method(
-                sel!(colorWithAlphaComponent:),
-                color_with_alpha_component as extern "C" fn(&Object, _, CGFloat) -> id
-            );
-            decl.add_method(
-                sel!(blendedColorWithFraction:ofColor:),
-                blended_color as extern "C" fn(&Object, _, CGFloat, id) -> id
-            );
-            decl.add_method(
-                sel!(colorWithSystemEffect:),
-                color_with_system_effect as extern "C" fn(&Object, _, NSInteger) -> id
-            );
-
-            decl.add_ivar::<id>(AQUA_LIGHT_COLOR_NORMAL_CONTRAST);
-            decl.add_ivar::<id>(AQUA_LIGHT_COLOR_HIGH_CONTRAST);
-            decl.add_ivar::<id>(AQUA_DARK_COLOR_NORMAL_CONTRAST);
-            decl.add_ivar::<id>(AQUA_DARK_COLOR_HIGH_CONTRAST);
-
-            VIEW_CLASS = decl.register();
-        });
-    }
-
-    unsafe { VIEW_CLASS }
+        decl.add_ivar::<id>(AQUA_LIGHT_COLOR_NORMAL_CONTRAST);
+        decl.add_ivar::<id>(AQUA_LIGHT_COLOR_HIGH_CONTRAST);
+        decl.add_ivar::<id>(AQUA_DARK_COLOR_NORMAL_CONTRAST);
+        decl.add_ivar::<id>(AQUA_DARK_COLOR_HIGH_CONTRAST);
+    })
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -47,7 +47,7 @@ pub enum Edge {
     MinX = 0,
     MinY = 1,
     MaxX = 2,
-    MaxY = 3,
+    MaxY = 3
 }
 impl From<Rect> for CGRect {
     fn from(rect: Rect) -> CGRect {

--- a/src/image/appkit.rs
+++ b/src/image/appkit.rs
@@ -25,15 +25,20 @@ use crate::view::{ViewDelegate, VIEW_DELEGATE_PTR};
 pub(crate) fn register_image_view_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTImageView";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSImageView);
-        let decl = ClassDecl::new("RSTImageView", superclass).unwrap();
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSImageView);
+            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
 
-        //decl.add_method(sel!(isFlipped), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
+            //decl.add_method(sel!(isFlipped), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
 
-        VIEW_CLASS = decl.register();
-    });
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }

--- a/src/image/appkit.rs
+++ b/src/image/appkit.rs
@@ -7,38 +7,15 @@
 //! for in the modern era. It also implements a few helpers for things like setting a background
 //! color, and enforcing layer backing by default.
 
-use std::sync::Once;
+use objc::runtime::Class;
 
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel, BOOL};
-use objc::{class, sel, sel_impl};
-use objc_id::Id;
-
-use crate::dragdrop::DragInfo;
-use crate::foundation::{id, NSUInteger, NO, YES};
-use crate::utils::load;
-use crate::view::{ViewDelegate, VIEW_DELEGATE_PTR};
+use crate::foundation::load_or_register_class;
 
 /// Injects an `NSView` subclass. This is used for the default views that don't use delegates - we
 /// have separate classes here since we don't want to waste cycles on methods that will never be
 /// used if there's no delegates.
 pub(crate) fn register_image_view_class() -> *const Class {
-    static mut VIEW_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTImageView";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { VIEW_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(NSImageView);
-            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-
-            //decl.add_method(sel!(isFlipped), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
-
-            VIEW_CLASS = decl.register();
-        });
-    }
-
-    unsafe { VIEW_CLASS }
+    load_or_register_class("NSImageView", "RSTImageView", |decl| unsafe {
+        //decl.add_method(sel!(isFlipped), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
+    })
 }

--- a/src/image/uikit.rs
+++ b/src/image/uikit.rs
@@ -15,12 +15,17 @@ use crate::view::{ViewDelegate, VIEW_DELEGATE_PTR};
 pub(crate) fn register_image_view_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTImageView";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(UIImageView);
-        let mut decl = ClassDecl::new("RSTImageView", superclass).expect("Failed to get RSTVIEW");
-        VIEW_CLASS = decl.register();
-    });
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(UIImageView);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).expect("Failed to get RSTVIEW");
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }

--- a/src/image/uikit.rs
+++ b/src/image/uikit.rs
@@ -1,31 +1,10 @@
-use std::sync::Once;
+use objc::runtime::Class;
 
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel, BOOL};
-use objc::{class, sel, sel_impl};
-use objc_id::Id;
-
-use crate::foundation::{id, NSUInteger, NO, YES};
-use crate::utils::load;
-use crate::view::{ViewDelegate, VIEW_DELEGATE_PTR};
+use crate::foundation::load_or_register_class;
 
 /// Injects an `NSView` subclass. This is used for the default views that don't use delegates - we
 /// have separate classes here since we don't want to waste cycles on methods that will never be
 /// used if there's no delegates.
 pub(crate) fn register_image_view_class() -> *const Class {
-    static mut VIEW_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTImageView";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { VIEW_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(UIImageView);
-            let mut decl = ClassDecl::new(CLASS_NAME, superclass).expect("Failed to get RSTVIEW");
-            VIEW_CLASS = decl.register();
-        });
-    }
-
-    unsafe { VIEW_CLASS }
+    load_or_register_class("UIImageView", "RSTImageView", |decl| unsafe {})
 }

--- a/src/input/appkit.rs
+++ b/src/input/appkit.rs
@@ -1,12 +1,7 @@
-use std::sync::Once;
-
-use objc::declare::ClassDecl;
 use objc::runtime::{Class, Object, Sel, BOOL};
-use objc::{class, msg_send, sel, sel_impl};
-use objc_id::Id;
+use objc::{msg_send, sel, sel_impl};
 
-use crate::dragdrop::DragInfo;
-use crate::foundation::{id, load_or_register_class, NSString, NSUInteger, NO, YES};
+use crate::foundation::{id, load_or_register_class, NSString, NO, YES};
 use crate::input::{TextFieldDelegate, TEXTFIELD_DELEGATE_PTR};
 use crate::utils::load;
 
@@ -52,21 +47,7 @@ extern "C" fn text_should_end_editing<T: TextFieldDelegate>(this: &mut Object, _
 /// have separate classes here since we don't want to waste cycles on methods that will never be
 /// used if there's no delegates.
 pub(crate) fn register_view_class() -> *const Class {
-    static mut VIEW_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTTextInputField";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { VIEW_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(NSTextField);
-            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-            VIEW_CLASS = decl.register();
-        });
-    }
-
-    unsafe { VIEW_CLASS }
+    load_or_register_class("NSTextField", "RSTTextInputField", |decl| unsafe {})
 }
 
 /// Injects an `NSTextField` subclass, with some callback and pointer ivars for what we

--- a/src/input/appkit.rs
+++ b/src/input/appkit.rs
@@ -54,12 +54,17 @@ extern "C" fn text_should_end_editing<T: TextFieldDelegate>(this: &mut Object, _
 pub(crate) fn register_view_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTTextInputField";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSTextField);
-        let decl = ClassDecl::new("RSTTextInputField", superclass).unwrap();
-        VIEW_CLASS = decl.register();
-    });
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSTextField);
+            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }

--- a/src/listview/appkit.rs
+++ b/src/listview/appkit.rs
@@ -187,12 +187,17 @@ extern "C" fn dragging_exited<T: ListViewDelegate>(this: &mut Object, _: Sel, in
 pub(crate) fn register_listview_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &'static str = "RSTListView";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSTableView);
-        let decl = ClassDecl::new("RSTListView", superclass).unwrap();
-        VIEW_CLASS = decl.register();
-    });
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSTableView);
+            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }

--- a/src/listview/appkit.rs
+++ b/src/listview/appkit.rs
@@ -7,16 +7,13 @@
 //! for in the modern era. It also implements a few helpers for things like setting a background
 //! color, and enforcing layer backing by default.
 
-use std::sync::Once;
-
-use objc::declare::ClassDecl;
 use objc::runtime::{Class, Object, Sel, BOOL};
-use objc::{class, msg_send, sel, sel_impl};
+use objc::{msg_send, sel, sel_impl};
 use objc_id::Id;
 
-use crate::appkit::menu::{Menu, MenuItem};
+use crate::appkit::menu::Menu;
 use crate::dragdrop::DragInfo;
-use crate::foundation::{id, load_or_register_class, nil, NSArray, NSInteger, NSUInteger, NO, YES};
+use crate::foundation::{id, load_or_register_class, NSArray, NSInteger, NSUInteger, NO, YES};
 use crate::listview::{ListViewDelegate, RowEdge, LISTVIEW_DELEGATE_PTR};
 use crate::utils::load;
 
@@ -185,21 +182,7 @@ extern "C" fn dragging_exited<T: ListViewDelegate>(this: &mut Object, _: Sel, in
 /// `UITableView` semantics; if `NSTableView`'s multi column behavior is needed, then it can
 /// be added in.
 pub(crate) fn register_listview_class() -> *const Class {
-    static mut VIEW_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &'static str = "RSTListView";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { VIEW_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(NSTableView);
-            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-            VIEW_CLASS = decl.register();
-        });
-    }
-
-    unsafe { VIEW_CLASS }
+    load_or_register_class("NSTableView", "RSTListView", |decl| unsafe {})
 }
 
 /// Injects an `NSTableView` subclass, with some callback and pointer ivars for what we

--- a/src/listview/row/appkit.rs
+++ b/src/listview/row/appkit.rs
@@ -109,15 +109,20 @@ extern "C" fn dealloc<T: ViewDelegate>(this: &Object, _: Sel) {
 pub(crate) fn register_listview_row_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTTableViewRow";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSView);
-        let mut decl = ClassDecl::new("RSTTableViewRow", superclass).unwrap();
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSView);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
 
-        decl.add_method(sel!(isFlipped), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
+            decl.add_method(sel!(isFlipped), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
 
-        VIEW_CLASS = decl.register();
-    });
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }
@@ -127,46 +132,51 @@ pub(crate) fn register_listview_row_class() -> *const Class {
 pub(crate) fn register_listview_row_class_with_delegate<T: ViewDelegate>() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTableViewRowWithDelegate";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSView);
-        let mut decl = ClassDecl::new("RSTableViewRowWithDelegate", superclass).unwrap();
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSView);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
 
-        // A pointer to the "view controller" on the Rust side. It's expected that this doesn't
-        // move.
-        decl.add_ivar::<usize>(LISTVIEW_ROW_DELEGATE_PTR);
-        decl.add_ivar::<id>(BACKGROUND_COLOR);
+            // A pointer to the "view controller" on the Rust side. It's expected that this doesn't
+            // move.
+            decl.add_ivar::<usize>(LISTVIEW_ROW_DELEGATE_PTR);
+            decl.add_ivar::<id>(BACKGROUND_COLOR);
 
-        decl.add_method(sel!(isFlipped), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
-        decl.add_method(sel!(updateLayer), update_layer as extern "C" fn(&Object, _));
+            decl.add_method(sel!(isFlipped), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
+            decl.add_method(sel!(updateLayer), update_layer as extern "C" fn(&Object, _));
 
-        // Drag and drop operations (e.g, accepting files)
-        decl.add_method(
-            sel!(draggingEntered:),
-            dragging_entered::<T> as extern "C" fn(&mut Object, _, _) -> NSUInteger
-        );
-        decl.add_method(
-            sel!(prepareForDragOperation:),
-            prepare_for_drag_operation::<T> as extern "C" fn(&mut Object, _, _) -> BOOL
-        );
-        decl.add_method(
-            sel!(performDragOperation:),
-            perform_drag_operation::<T> as extern "C" fn(&mut Object, _, _) -> BOOL
-        );
-        decl.add_method(
-            sel!(concludeDragOperation:),
-            conclude_drag_operation::<T> as extern "C" fn(&mut Object, _, _)
-        );
-        decl.add_method(
-            sel!(draggingExited:),
-            dragging_exited::<T> as extern "C" fn(&mut Object, _, _)
-        );
+            // Drag and drop operations (e.g, accepting files)
+            decl.add_method(
+                sel!(draggingEntered:),
+                dragging_entered::<T> as extern "C" fn(&mut Object, _, _) -> NSUInteger
+            );
+            decl.add_method(
+                sel!(prepareForDragOperation:),
+                prepare_for_drag_operation::<T> as extern "C" fn(&mut Object, _, _) -> BOOL
+            );
+            decl.add_method(
+                sel!(performDragOperation:),
+                perform_drag_operation::<T> as extern "C" fn(&mut Object, _, _) -> BOOL
+            );
+            decl.add_method(
+                sel!(concludeDragOperation:),
+                conclude_drag_operation::<T> as extern "C" fn(&mut Object, _, _)
+            );
+            decl.add_method(
+                sel!(draggingExited:),
+                dragging_exited::<T> as extern "C" fn(&mut Object, _, _)
+            );
 
-        // Cleanup
-        decl.add_method(sel!(dealloc), dealloc::<T> as extern "C" fn(&Object, _));
+            // Cleanup
+            decl.add_method(sel!(dealloc), dealloc::<T> as extern "C" fn(&Object, _));
 
-        VIEW_CLASS = decl.register();
-    });
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }

--- a/src/listview/row/uikit.rs
+++ b/src/listview/row/uikit.rs
@@ -1,53 +1,24 @@
-use std::sync::Once;
-
 use objc::declare::ClassDecl;
 use objc::runtime::{Class, Object, Sel, BOOL};
 use objc::{class, sel, sel_impl};
 use objc_id::Id;
 
-use crate::foundation::{id, YES, NO, NSUInteger};
 use crate::dragdrop::DragInfo;
-use crate::view::{VIEW_DELEGATE_PTR, ViewDelegate};
+use crate::foundation::{id, NSUInteger, NO, YES};
 use crate::utils::load;
+use crate::view::{ViewDelegate, VIEW_DELEGATE_PTR};
 
 /// Injects an `NSView` subclass. This is used for the default views that don't use delegates - we
 /// have separate classes here since we don't want to waste cycles on methods that will never be
 /// used if there's no delegates.
 pub(crate) fn register_view_class() -> *const Class {
-    static mut VIEW_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTView";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { VIEW_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(UIView);
-            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-            VIEW_CLASS = decl.register();
-        });
-    }
-
-    unsafe { VIEW_CLASS }
+    load_or_register_class("UIView", "RSTView", |decl| unsafe {})
 }
 
 /// Injects an `NSView` subclass, with some callback and pointer ivars for what we
 /// need to do.
 pub(crate) fn register_view_class_with_delegate<T: ViewDelegate>() -> *const Class {
-    static mut VIEW_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTViewWithDelegate";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { VIEW_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(UIView);
-            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-            decl.add_ivar::<usize>(VIEW_DELEGATE_PTR);
-            VIEW_CLASS = decl.register();
-        });
-    }
-
-    unsafe { VIEW_CLASS }
+    load_or_register_class("UIView", "RSTViewWithDelegate", |decl| unsafe {
+        decl.add_ivar::<usize>(VIEW_DELEGATE_PTR);
+    })
 }

--- a/src/listview/row/uikit.rs
+++ b/src/listview/row/uikit.rs
@@ -16,12 +16,17 @@ use crate::utils::load;
 pub(crate) fn register_view_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTView";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(UIView);
-        let mut decl = ClassDecl::new("RSTView", superclass).unwrap();
-        VIEW_CLASS = decl.register();
-    });
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(UIView);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }
@@ -31,15 +36,18 @@ pub(crate) fn register_view_class() -> *const Class {
 pub(crate) fn register_view_class_with_delegate<T: ViewDelegate>() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTViewWithDelegate";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(UIView);
-        let mut decl = ClassDecl::new("RSTViewWithDelegate", superclass).unwrap();
-        decl.add_ivar::<usize>(VIEW_DELEGATE_PTR);
-        VIEW_CLASS = decl.register();
-    });
-
-    unsafe {
-        VIEW_CLASS
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(UIView);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            decl.add_ivar::<usize>(VIEW_DELEGATE_PTR);
+            VIEW_CLASS = decl.register();
+        });
     }
+
+    unsafe { VIEW_CLASS }
 }

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -270,12 +270,17 @@ impl Drop for Select {
 fn register_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "CacaoSelect";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSPopUpButton);
-        let decl = ClassDecl::new("CacaoSelect", superclass).unwrap();
-        VIEW_CLASS = decl.register();
-    });
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSPopUpButton);
+            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -1,24 +1,19 @@
 //! Implements a Select-style dropdown. By default this uses NSPopupSelect on macOS.
 
-use std::sync::Once;
-
 use core_graphics::geometry::CGRect;
-
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel};
-use objc::{class, msg_send, sel, sel_impl};
+use objc::runtime::{Class, Object};
+use objc::{msg_send, sel, sel_impl};
 use objc_id::ShareId;
 
 use crate::control::Control;
-use crate::foundation::{id, nil, NSInteger, NSString, NO, YES};
+use crate::foundation::{id, load_or_register_class, nil, NSInteger, NSString, NO, YES};
 use crate::geometry::Rect;
 use crate::invoker::TargetActionHandler;
 use crate::layout::Layout;
-use crate::objc_access::ObjcAccess;
-use crate::utils::properties::ObjcProperty;
-
 #[cfg(feature = "autolayout")]
 use crate::layout::{LayoutAnchorDimension, LayoutAnchorX, LayoutAnchorY};
+use crate::objc_access::ObjcAccess;
+use crate::utils::properties::ObjcProperty;
 
 /// Wraps `NSPopUpSelect` on AppKit. Not currently implemented for iOS.
 ///
@@ -268,19 +263,5 @@ impl Drop for Select {
 /// Registers an `NSSelect` subclass, and configures it to hold some ivars
 /// for various things we need to store.
 fn register_class() -> *const Class {
-    static mut VIEW_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "CacaoSelect";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { VIEW_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(NSPopUpButton);
-            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-            VIEW_CLASS = decl.register();
-        });
-    }
-
-    unsafe { VIEW_CLASS }
+    load_or_register_class("NSPopUpButton", "CacaoSelect", |decl| unsafe {})
 }

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -180,12 +180,19 @@ impl Drop for Switch {
 fn register_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTSwitch";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSButton);
-        let decl = ClassDecl::new("RSTSwitch", superclass).unwrap();
-        VIEW_CLASS = decl.register();
-    });
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe {
+            VIEW_CLASS = c;
+        }
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSButton);
+            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -1,22 +1,17 @@
 //! A wrapper for NSSwitch. Currently the epitome of jank - if you're poking around here, expect
 //! that this will change at some point.
 
-use std::fmt;
-use std::sync::Once;
-
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel};
-use objc::{class, msg_send, sel, sel_impl};
+use objc::runtime::{Class, Object};
+use objc::{msg_send, sel, sel_impl};
 use objc_id::ShareId;
 
-use crate::foundation::{id, nil, NSString, BOOL, NO, YES};
+use crate::foundation::{id, load_or_register_class, nil, NSString, NO};
 use crate::invoker::TargetActionHandler;
 use crate::layout::Layout;
-use crate::objc_access::ObjcAccess;
-use crate::utils::{load, properties::ObjcProperty};
-
 #[cfg(feature = "autolayout")]
 use crate::layout::{LayoutAnchorDimension, LayoutAnchorX, LayoutAnchorY};
+use crate::objc_access::ObjcAccess;
+use crate::utils::properties::ObjcProperty;
 
 /// A wrapper for `NSSwitch`. Holds (retains) pointers for the Objective-C runtime
 /// where our `NSSwitch` lives.
@@ -178,21 +173,5 @@ impl Drop for Switch {
 /// Registers an `NSButton` subclass, and configures it to hold some ivars
 /// for various things we need to store.
 fn register_class() -> *const Class {
-    static mut VIEW_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTSwitch";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe {
-            VIEW_CLASS = c;
-        }
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(NSButton);
-            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-            VIEW_CLASS = decl.register();
-        });
-    }
-
-    unsafe { VIEW_CLASS }
+    load_or_register_class("NSButton", "RSTSwitch", |decl| unsafe {})
 }

--- a/src/text/label/appkit.rs
+++ b/src/text/label/appkit.rs
@@ -25,12 +25,17 @@ use crate::utils::load;
 pub(crate) fn register_view_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTTextField";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSTextField);
-        let decl = ClassDecl::new("RSTTextField", superclass).unwrap();
-        VIEW_CLASS = decl.register();
-    });
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSTextField);
+            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }
@@ -40,17 +45,22 @@ pub(crate) fn register_view_class() -> *const Class {
 pub(crate) fn register_view_class_with_delegate<T: LabelDelegate>() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTTextFieldWithDelegate";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSView);
-        let mut decl = ClassDecl::new("RSTTextFieldWithDelegate", superclass).unwrap();
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSView);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
 
-        // A pointer to the "view controller" on the Rust side. It's expected that this doesn't
-        // move.
-        decl.add_ivar::<usize>(LABEL_DELEGATE_PTR);
+            // A pointer to the "view controller" on the Rust side. It's expected that this doesn't
+            // move.
+            decl.add_ivar::<usize>(LABEL_DELEGATE_PTR);
 
-        VIEW_CLASS = decl.register();
-    });
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }

--- a/src/text/label/appkit.rs
+++ b/src/text/label/appkit.rs
@@ -7,60 +7,24 @@
 //! for in the modern era. It also implements a few helpers for things like setting a background
 //! color, and enforcing layer backing by default.
 
-use std::sync::Once;
+use objc::runtime::Class;
 
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel, BOOL};
-use objc::{class, sel, sel_impl};
-use objc_id::Id;
-
-use crate::dragdrop::DragInfo;
-use crate::foundation::{id, NSUInteger, NO, YES};
+use crate::foundation::load_or_register_class;
 use crate::text::label::{LabelDelegate, LABEL_DELEGATE_PTR};
-use crate::utils::load;
 
 /// Injects an `NSTextField` subclass. This is used for the default views that don't use delegates - we
 /// have separate classes here since we don't want to waste cycles on methods that will never be
 /// used if there's no delegates.
 pub(crate) fn register_view_class() -> *const Class {
-    static mut VIEW_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTTextField";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { VIEW_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(NSTextField);
-            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-            VIEW_CLASS = decl.register();
-        });
-    }
-
-    unsafe { VIEW_CLASS }
+    load_or_register_class("NSTextField", "RSTTextField", |decl| unsafe {})
 }
 
 /// Injects an `NSTextField` subclass, with some callback and pointer ivars for what we
 /// need to do.
 pub(crate) fn register_view_class_with_delegate<T: LabelDelegate>() -> *const Class {
-    static mut VIEW_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTTextFieldWithDelegate";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { VIEW_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(NSView);
-            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-
-            // A pointer to the "view controller" on the Rust side. It's expected that this doesn't
-            // move.
-            decl.add_ivar::<usize>(LABEL_DELEGATE_PTR);
-
-            VIEW_CLASS = decl.register();
-        });
-    }
-
-    unsafe { VIEW_CLASS }
+    load_or_register_class("NSView", "RSTTextFieldWithDelegate", |decl| unsafe {
+        // A pointer to the "view controller" on the Rust side. It's expected that this doesn't
+        // move.
+        decl.add_ivar::<usize>(LABEL_DELEGATE_PTR);
+    })
 }

--- a/src/uikit/app/class.rs
+++ b/src/uikit/app/class.rs
@@ -2,27 +2,11 @@
 //! creates a custom `UIApplication` subclass that currently does nothing; this is meant as a hook
 //! for potential future use.
 
-use std::sync::Once;
-
-use objc::class;
-use objc::declare::ClassDecl;
 use objc::runtime::Class;
+
+use crate::foundation::load_or_register_class;
 
 /// Used for injecting a custom UIApplication. Currently does nothing.
 pub(crate) fn register_app_class() -> *const Class {
-    static mut APP_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTApplication";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { APP_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(UIApplication);
-            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-            APP_CLASS = decl.register();
-        });
-    }
-
-    unsafe { APP_CLASS }
+    load_or_register_class("UIApplication", "RSTApplication", |decl| unsafe {})
 }

--- a/src/uikit/app/class.rs
+++ b/src/uikit/app/class.rs
@@ -12,12 +12,17 @@ use objc::runtime::Class;
 pub(crate) fn register_app_class() -> *const Class {
     static mut APP_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTApplication";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(UIApplication);
-        let decl = ClassDecl::new("RSTApplication", superclass).unwrap();
-        APP_CLASS = decl.register();
-    });
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { APP_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(UIApplication);
+            let decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            APP_CLASS = decl.register();
+        });
+    }
 
     unsafe { APP_CLASS }
 }

--- a/src/uikit/app/delegate.rs
+++ b/src/uikit/app/delegate.rs
@@ -51,29 +51,34 @@ extern "C" fn configuration_for_scene_session<T: AppDelegate>(this: &Object, _: 
 pub(crate) fn register_app_delegate_class<T: AppDelegate>() -> *const Class {
     static mut DELEGATE_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTAppDelegate";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSObject);
-        let mut decl = ClassDecl::new("RSTAppDelegate", superclass).unwrap();
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { DELEGATE_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSObject);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
 
-        // Launching Applications
-        decl.add_method(
-            sel!(application:didFinishLaunchingWithOptions:),
-            did_finish_launching::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
-        );
+            // Launching Applications
+            decl.add_method(
+                sel!(application:didFinishLaunchingWithOptions:),
+                did_finish_launching::<T> as extern "C" fn(&Object, _, _, id) -> BOOL
+            );
 
-        // Scenes
-        decl.add_method(
-            sel!(application:configurationForConnectingSceneSession:options:),
-            configuration_for_scene_session::<T> as extern "C" fn(&Object, _, _, id, id) -> id
-        );
-        /*decl.add_method(
-            sel!(application:didDiscardSceneSessions:),
-            did_discard_scene_sessions::<T> as extern "C" fn(&Object, _, _, id)
-        );*/
+            // Scenes
+            decl.add_method(
+                sel!(application:configurationForConnectingSceneSession:options:),
+                configuration_for_scene_session::<T> as extern "C" fn(&Object, _, _, id, id) -> id
+            );
+            /*decl.add_method(
+                sel!(application:didDiscardSceneSessions:),
+                did_discard_scene_sessions::<T> as extern "C" fn(&Object, _, _, id)
+            );*/
 
-        DELEGATE_CLASS = decl.register();
-    });
+            DELEGATE_CLASS = decl.register();
+        });
+    }
 
     unsafe { DELEGATE_CLASS }
 }

--- a/src/uikit/scene/delegate.rs
+++ b/src/uikit/scene/delegate.rs
@@ -1,25 +1,10 @@
-use std::ffi::c_void;
-use std::sync::Once;
-use std::unreachable;
-
-use block::Block;
-
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel};
+use objc::runtime::{Class, Object, Protocol, Sel};
 use objc::{class, msg_send, sel, sel_impl};
 
-use url::Url;
-
-use crate::error::Error;
-use crate::foundation::{id, nil, NSArray, NSString, NSUInteger, BOOL, NO, YES};
-use crate::user_activity::UserActivity;
-use crate::utils::load;
-
+use crate::foundation::{id, load_or_register_class};
 use crate::uikit::app::SCENE_DELEGATE_VENDOR;
-use crate::uikit::scene::{Scene, SceneConfig, SceneConnectionOptions, SceneSession, WindowSceneDelegate};
-
-#[cfg(feature = "cloudkit")]
-use crate::cloudkit::share::CKShareMetaData;
+use crate::uikit::scene::{Scene, SceneConnectionOptions, SceneSession, WindowSceneDelegate};
+use crate::utils::load;
 
 pub(crate) static WINDOW_SCENE_PTR: &str = "rstWindowSceneDelegatePtr";
 
@@ -60,37 +45,20 @@ extern "C" fn scene_will_connect_to_session_with_options<T: WindowSceneDelegate>
 /// Registers an `NSObject` application delegate, and configures it for the various callbacks and
 /// pointers we need to have.
 pub(crate) fn register_window_scene_delegate_class<T: WindowSceneDelegate, F: Fn() -> Box<T>>() -> *const Class {
-    static mut DELEGATE_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTWindowSceneDelegate";
+    load_or_register_class("UIResponder", "RSTWindowSceneDelegate", |decl| unsafe {
+        let p = Protocol::get("UIWindowSceneDelegate").unwrap();
 
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { DELEGATE_CLASS = c };
-    } else {
-        use objc::runtime::Protocol;
-        INIT.call_once(|| unsafe {
-            let superclass = class!(UIResponder);
-            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+        // A spot to hold a pointer to
+        decl.add_ivar::<usize>(WINDOW_SCENE_PTR);
+        decl.add_protocol(p);
 
-            let p = Protocol::get("UIWindowSceneDelegate").unwrap();
+        // Override the `init` call to handle creating and attaching a WindowSceneDelegate.
+        decl.add_method(sel!(init), init::<T, F> as extern "C" fn(&mut Object, _) -> id);
 
-            // A spot to hold a pointer to
-            decl.add_ivar::<usize>(WINDOW_SCENE_PTR);
-            decl.add_protocol(p);
-
-            // Override the `init` call to handle creating and attaching a WindowSceneDelegate.
-            decl.add_method(sel!(init), init::<T, F> as extern "C" fn(&mut Object, _) -> id);
-
-            // UIWindowSceneDelegate API
-            decl.add_method(
-                sel!(scene:willConnectToSession:options:),
-                scene_will_connect_to_session_with_options::<T> as extern "C" fn(&Object, _, _, _, _)
-            );
-
-            // Launching Applications
-            DELEGATE_CLASS = decl.register();
-        });
-    }
-
-    unsafe { DELEGATE_CLASS }
+        // UIWindowSceneDelegate API
+        decl.add_method(
+            sel!(scene:willConnectToSession:options:),
+            scene_will_connect_to_session_with_options::<T> as extern "C" fn(&Object, _, _, _, _)
+        );
+    })
 }

--- a/src/view/appkit.rs
+++ b/src/view/appkit.rs
@@ -94,19 +94,24 @@ extern "C" fn update_layer(this: &Object, _: Sel) {
 pub(crate) fn register_view_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTView";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(NSView);
-        let mut decl = ClassDecl::new("RSTView", superclass).unwrap();
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(NSView);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
 
-        decl.add_method(sel!(isFlipped), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
-        decl.add_method(sel!(updateLayer), update_layer as extern "C" fn(&Object, _));
-        decl.add_method(sel!(wantsUpdateLayer), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
+            decl.add_method(sel!(isFlipped), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
+            decl.add_method(sel!(updateLayer), update_layer as extern "C" fn(&Object, _));
+            decl.add_method(sel!(wantsUpdateLayer), enforce_normalcy as extern "C" fn(&Object, _) -> BOOL);
 
-        decl.add_ivar::<id>(BACKGROUND_COLOR);
+            decl.add_ivar::<id>(BACKGROUND_COLOR);
 
-        VIEW_CLASS = decl.register();
-    });
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }

--- a/src/view/popover/mod.rs
+++ b/src/view/popover/mod.rs
@@ -20,14 +20,14 @@ pub enum PopoverBehaviour {
     /// The system will close the popover when the user interacts with a user interface element outside the popover.
     Transient = 1,
     /// The system will close the popover when the user interacts with user interface elements in the window containing the popover's positioning view.
-    Semitransient = 2,
+    Semitransient = 2
 }
 
 #[derive(Debug)]
 pub struct PopoverConfig {
     pub content_size: CGSize,
     pub animates: bool,
-    pub behaviour: PopoverBehaviour,
+    pub behaviour: PopoverBehaviour
 }
 
 impl Default for PopoverConfig {
@@ -35,10 +35,10 @@ impl Default for PopoverConfig {
         Self {
             content_size: CGSize {
                 width: 320.0,
-                height: 320.0,
+                height: 320.0
             },
             animates: true,
-            behaviour: PopoverBehaviour::Transient,
+            behaviour: PopoverBehaviour::Transient
         }
     }
 }
@@ -49,12 +49,12 @@ pub struct Popover<Content> {
     pub objc: ShareId<Object>,
 
     /// The wrapped ViewController.
-    pub view_controller: ViewController<Content>,
+    pub view_controller: ViewController<Content>
 }
 
 impl<Content> Popover<Content>
 where
-    Content: ViewDelegate + 'static,
+    Content: ViewDelegate + 'static
 {
     pub fn new(content: Content, config: PopoverConfig) -> Self {
         let view_controller = ViewController::new(content);

--- a/src/view/splitviewcontroller/ios.rs
+++ b/src/view/splitviewcontroller/ios.rs
@@ -9,7 +9,7 @@ use crate::view::{ViewDelegate, VIEW_DELEGATE_PTR};
 /// Called when the view controller receives a `viewWillAppear:` message.
 extern "C" fn will_appear<T: ViewDelegate>(this: &mut Object, _: Sel, animated: BOOL) {
     unsafe {
-        let _: () = msg_send![super(this, class!(UIViewController)), viewWillAppear:animated];
+        let _: () = msg_send![super(this, class!(UIViewController)), viewWillAppear: animated];
     }
 
     let controller = load::<T>(this, VIEW_DELEGATE_PTR);
@@ -19,7 +19,7 @@ extern "C" fn will_appear<T: ViewDelegate>(this: &mut Object, _: Sel, animated: 
 /// Called when the view controller receives a `viewDidAppear:` message.
 extern "C" fn did_appear<T: ViewDelegate>(this: &mut Object, _: Sel, animated: BOOL) {
     unsafe {
-        let _: () = msg_send![super(this, class!(UIViewController)), viewDidAppear:animated];
+        let _: () = msg_send![super(this, class!(UIViewController)), viewDidAppear: animated];
     }
 
     let controller = load::<T>(this, VIEW_DELEGATE_PTR);
@@ -29,7 +29,7 @@ extern "C" fn did_appear<T: ViewDelegate>(this: &mut Object, _: Sel, animated: B
 /// Called when the view controller receives a `viewWillDisappear:` message.
 extern "C" fn will_disappear<T: ViewDelegate>(this: &mut Object, _: Sel, animated: BOOL) {
     unsafe {
-        let _: () = msg_send![super(this, class!(UIViewController)), viewWillDisappear:animated];
+        let _: () = msg_send![super(this, class!(UIViewController)), viewWillDisappear: animated];
     }
 
     let controller = load::<T>(this, VIEW_DELEGATE_PTR);
@@ -39,7 +39,7 @@ extern "C" fn will_disappear<T: ViewDelegate>(this: &mut Object, _: Sel, animate
 /// Called when the view controller receives a `viewDidDisappear:` message.
 extern "C" fn did_disappear<T: ViewDelegate>(this: &mut Object, _: Sel, animated: BOOL) {
     unsafe {
-        let _: () = msg_send![super(this, class!(UIViewController)), viewDidDisappear:animated];
+        let _: () = msg_send![super(this, class!(UIViewController)), viewDidDisappear: animated];
     }
 
     let controller = load::<T>(this, VIEW_DELEGATE_PTR);

--- a/src/view/uikit.rs
+++ b/src/view/uikit.rs
@@ -1,5 +1,3 @@
-use std::sync::Once;
-
 use objc::declare::ClassDecl;
 use objc::runtime::{Class, Object, Sel, BOOL};
 use objc::{class, sel, sel_impl};
@@ -14,21 +12,7 @@ use crate::view::{ViewDelegate, VIEW_DELEGATE_PTR};
 /// have separate classes here since we don't want to waste cycles on methods that will never be
 /// used if there's no delegates.
 pub(crate) fn register_view_class() -> *const Class {
-    static mut VIEW_CLASS: *const Class = 0 as *const Class;
-    static INIT: Once = Once::new();
-    const CLASS_NAME: &str = "RSTView";
-
-    if let Some(c) = Class::get(CLASS_NAME) {
-        unsafe { VIEW_CLASS = c };
-    } else {
-        INIT.call_once(|| unsafe {
-            let superclass = class!(UIView);
-            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
-            VIEW_CLASS = decl.register();
-        });
-    }
-
-    unsafe { VIEW_CLASS }
+    load_or_register_class("UIView", "RSTView", |decl| unsafe {})
 }
 
 /// Injects a `UIView` subclass, with some callback and pointer ivars for what we

--- a/src/view/uikit.rs
+++ b/src/view/uikit.rs
@@ -16,12 +16,17 @@ use crate::view::{ViewDelegate, VIEW_DELEGATE_PTR};
 pub(crate) fn register_view_class() -> *const Class {
     static mut VIEW_CLASS: *const Class = 0 as *const Class;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTView";
 
-    INIT.call_once(|| unsafe {
-        let superclass = class!(UIView);
-        let mut decl = ClassDecl::new("RSTView", superclass).unwrap();
-        VIEW_CLASS = decl.register();
-    });
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { VIEW_CLASS = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = class!(UIView);
+            let mut decl = ClassDecl::new(CLASS_NAME, superclass).unwrap();
+            VIEW_CLASS = decl.register();
+        });
+    }
 
     unsafe { VIEW_CLASS }
 }

--- a/src/webview/process_pool.rs
+++ b/src/webview/process_pool.rs
@@ -28,17 +28,22 @@ extern "C" fn download_delegate(this: &Object, _: Sel) -> id {
 pub fn register_process_pool() -> *const Object {
     static mut PROCESS_POOL: *const Object = 0 as *const Object;
     static INIT: Once = Once::new();
+    const CLASS_NAME: &str = "RSTWebViewProcessPool";
 
-    INIT.call_once(|| unsafe {
-        let superclass = Class::get("WKProcessPool").unwrap();
-        let mut decl = ClassDecl::new("RSTWebViewProcessPool", superclass).unwrap();
+    if let Some(c) = Class::get(CLASS_NAME) {
+        unsafe { PROCESS_POOL = c };
+    } else {
+        INIT.call_once(|| unsafe {
+            let superclass = Class::get("WKProcessPool").unwrap();
+            let mut decl = ClassDecl::new("RSTWebViewProcessPool", superclass).unwrap();
 
-        //decl.add_ivar::<id>(DOWNLOAD_DELEGATE_PTR);
-        decl.add_method(sel!(_downloadDelegate), download_delegate as extern "C" fn(&Object, _) -> id);
+            //decl.add_ivar::<id>(DOWNLOAD_DELEGATE_PTR);
+            decl.add_method(sel!(_downloadDelegate), download_delegate as extern "C" fn(&Object, _) -> id);
 
-        //PROCESS_POOL = decl.register();
-        PROCESS_POOL = msg_send![decl.register(), new];
-    });
+            //PROCESS_POOL = decl.register();
+            PROCESS_POOL = msg_send![decl.register(), new];
+        });
+    }
 
     unsafe { PROCESS_POOL }
 }


### PR DESCRIPTION
This can happen in environments like plugins, where cacao can exist multiple times and thus tries to create and register its objc classes more than once.

I'm using cacao to implement interface elements in Adobe Illustrator plugins. Whenever I had more than one of those added in parallel to Illustrator, it crashed. Reason was, that the objc classes for the interface elements like button, label or image were registered multiple times. This lead to a `None` returned that was `unwrap()` in a panic.

This code just checks if a to-be-registered class already exists and if so, returns it. Obviously, it can't change any added elements and just assumes we want to register the same class. 

I didn't touch the `fn load_or_register_class()`, as this seems to already handle the situation.