### PR TITLE
Fixed building for iOS.

### DIFF
--- a/src/view/popover/mod.rs
+++ b/src/view/popover/mod.rs
@@ -3,9 +3,13 @@ use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl};
 use objc_id::ShareId;
 
+#[cfg(feature = "appkit")]
 use crate::appkit::toolbar::ToolbarItem;
+#[cfg(feature = "appkit")]
 use crate::appkit::window::Window;
+#[cfg(feature = "appkit")]
 use crate::appkit::App;
+
 use crate::foundation::{id, nil, NSString};
 use crate::geometry::{Edge, Rect};
 use crate::layout::Layout;
@@ -84,6 +88,7 @@ impl<Content> Popover<Content> {
     }
 
     /// Show the popover relative to the content view of the main window
+    #[cfg(feature = "appkit")]
     pub fn show_popover_main(&self, rect: Rect, edge: Edge) {
         let window = App::main_window();
         unsafe {


### PR DESCRIPTION
I’ve fixed the build for iOS, but the example now crashes on launch with the following error:

```
*** Assertion failure in Class _UIApplicationGetPrincipalClass(NSString *__strong)(), UIApplication.m:5111
*** -[NSAutoreleasePool release]: This pool has already been drained, do not release it (double release).
fatal runtime error: Rust cannot catch foreign exceptions
```

I’ve not been able to work out the cause, so any pointers there would be appreciated. 

Thanks,
Luke