### PR TITLE
Multiple changes I had to make for Ebou

### DIFF
--- a/examples/calculator/content_view.rs
+++ b/examples/calculator/content_view.rs
@@ -35,7 +35,7 @@ pub struct CalculatorView {
     pub row3: ButtonRow,
     pub dot: Button,
     pub zero: Button,
-    pub equals: Button,
+    pub equals: Button
 }
 
 impl CalculatorView {
@@ -56,30 +56,30 @@ impl CalculatorView {
             row0: ButtonRow::new(
                 [Msg::Clear, Msg::Invert, Msg::Mod, Msg::Divide],
                 Color::rgb(69, 69, 69),
-                Color::rgb(255, 148, 10),
+                Color::rgb(255, 148, 10)
             ),
 
             row1: ButtonRow::new(
                 [Msg::Push(7), Msg::Push(8), Msg::Push(9), Msg::Multiply],
                 Color::rgb(100, 100, 100),
-                Color::rgb(255, 148, 10),
+                Color::rgb(255, 148, 10)
             ),
 
             row2: ButtonRow::new(
                 [Msg::Push(4), Msg::Push(5), Msg::Push(6), Msg::Subtract],
                 Color::rgb(100, 100, 100),
-                Color::rgb(255, 148, 10),
+                Color::rgb(255, 148, 10)
             ),
 
             row3: ButtonRow::new(
                 [Msg::Push(1), Msg::Push(2), Msg::Push(3), Msg::Add],
                 Color::rgb(100, 100, 100),
-                Color::rgb(255, 148, 10),
+                Color::rgb(255, 148, 10)
             ),
 
             zero: button("0", Msg::Push(0)),
             dot: button(".", Msg::Decimal),
-            equals: button("=", Msg::Equals),
+            equals: button("=", Msg::Equals)
         }
     }
 
@@ -158,7 +158,7 @@ impl ViewDelegate for CalculatorView {
             self.equals.trailing.constraint_equal_to(&view.trailing),
             self.equals.bottom.constraint_equal_to(&view.bottom),
             self.equals.width.constraint_equal_to_constant(BUTTON_WIDTH),
-            self.equals.height.constraint_equal_to_constant(BUTTON_HEIGHT),
+            self.equals.height.constraint_equal_to_constant(BUTTON_HEIGHT)
         ])
     }
 }

--- a/examples/calculator/content_view.rs
+++ b/examples/calculator/content_view.rs
@@ -16,7 +16,7 @@ pub fn button(text: &str, msg: Msg) -> Button {
     button.set_bordered(false);
     button.set_bezel_style(BezelStyle::SmallSquare);
     button.set_focus_ring_type(FocusRingType::None);
-    button.set_action(move || dispatch(msg.clone()));
+    button.set_action(move |_| dispatch(msg.clone()));
     button.set_key_equivalent(&*text.to_lowercase());
 
     let font = Font::system(22.);
@@ -35,7 +35,7 @@ pub struct CalculatorView {
     pub row3: ButtonRow,
     pub dot: Button,
     pub zero: Button,
-    pub equals: Button
+    pub equals: Button,
 }
 
 impl CalculatorView {
@@ -56,30 +56,30 @@ impl CalculatorView {
             row0: ButtonRow::new(
                 [Msg::Clear, Msg::Invert, Msg::Mod, Msg::Divide],
                 Color::rgb(69, 69, 69),
-                Color::rgb(255, 148, 10)
+                Color::rgb(255, 148, 10),
             ),
 
             row1: ButtonRow::new(
                 [Msg::Push(7), Msg::Push(8), Msg::Push(9), Msg::Multiply],
                 Color::rgb(100, 100, 100),
-                Color::rgb(255, 148, 10)
+                Color::rgb(255, 148, 10),
             ),
 
             row2: ButtonRow::new(
                 [Msg::Push(4), Msg::Push(5), Msg::Push(6), Msg::Subtract],
                 Color::rgb(100, 100, 100),
-                Color::rgb(255, 148, 10)
+                Color::rgb(255, 148, 10),
             ),
 
             row3: ButtonRow::new(
                 [Msg::Push(1), Msg::Push(2), Msg::Push(3), Msg::Add],
                 Color::rgb(100, 100, 100),
-                Color::rgb(255, 148, 10)
+                Color::rgb(255, 148, 10),
             ),
 
             zero: button("0", Msg::Push(0)),
             dot: button(".", Msg::Decimal),
-            equals: button("=", Msg::Equals)
+            equals: button("=", Msg::Equals),
         }
     }
 
@@ -158,7 +158,7 @@ impl ViewDelegate for CalculatorView {
             self.equals.trailing.constraint_equal_to(&view.trailing),
             self.equals.bottom.constraint_equal_to(&view.bottom),
             self.equals.width.constraint_equal_to_constant(BUTTON_WIDTH),
-            self.equals.height.constraint_equal_to_constant(BUTTON_HEIGHT)
+            self.equals.height.constraint_equal_to_constant(BUTTON_HEIGHT),
         ])
     }
 }

--- a/examples/popover.rs
+++ b/examples/popover.rs
@@ -17,35 +17,29 @@ use cacao::notification_center::Dispatcher;
 use cacao::view::{Popover, PopoverConfig, View, ViewController, ViewDelegate};
 
 struct BasicApp {
-    window: WindowController<MyWindow>,
+    window: WindowController<MyWindow>
 }
 
 impl AppDelegate for BasicApp {
     fn did_finish_launching(&self) {
         App::set_menu(vec![
-            Menu::new(
-                "",
-                vec![
-                    MenuItem::Services,
-                    MenuItem::Separator,
-                    MenuItem::Hide,
-                    MenuItem::HideOthers,
-                    MenuItem::ShowAll,
-                    MenuItem::Separator,
-                    MenuItem::Quit,
-                ],
-            ),
+            Menu::new("", vec![
+                MenuItem::Services,
+                MenuItem::Separator,
+                MenuItem::Hide,
+                MenuItem::HideOthers,
+                MenuItem::ShowAll,
+                MenuItem::Separator,
+                MenuItem::Quit,
+            ]),
             Menu::new("File", vec![MenuItem::CloseWindow]),
             Menu::new("View", vec![MenuItem::EnterFullScreen]),
-            Menu::new(
-                "Window",
-                vec![
-                    MenuItem::Minimize,
-                    MenuItem::Zoom,
-                    MenuItem::Separator,
-                    MenuItem::new("Bring All to Front"),
-                ],
-            ),
+            Menu::new("Window", vec![
+                MenuItem::Minimize,
+                MenuItem::Zoom,
+                MenuItem::Separator,
+                MenuItem::new("Bring All to Front"),
+            ]),
         ]);
 
         App::activate();
@@ -60,7 +54,7 @@ impl AppDelegate for BasicApp {
 
 #[derive(Default)]
 struct MyWindow {
-    controller: Option<ViewController<PopoverExampleContentView>>,
+    controller: Option<ViewController<PopoverExampleContentView>>
 }
 
 impl WindowDelegate for MyWindow {
@@ -89,25 +83,22 @@ impl MyWindow {
 }
 
 fn main() {
-    App::new(
-        "com.test.window-delegate",
-        BasicApp {
-            window: WindowController::with(WindowConfig::default(), MyWindow::default()),
-        },
-    )
+    App::new("com.test.window-delegate", BasicApp {
+        window: WindowController::with(WindowConfig::default(), MyWindow::default())
+    })
     .run();
 }
 
 #[derive(Clone, Debug)]
 pub enum Msg {
-    Click,
+    Click
 }
 
 #[derive(Debug, Default)]
 struct PopoverExampleContentView {
     view: Option<View>,
     button: Option<Button>,
-    popover: Option<Popover<PopoverExampleContentViewController>>,
+    popover: Option<Popover<PopoverExampleContentViewController>>
 }
 
 impl PopoverExampleContentView {
@@ -115,7 +106,7 @@ impl PopoverExampleContentView {
         Self {
             view: None,
             button: None,
-            popover: None,
+            popover: None
         }
     }
 
@@ -125,7 +116,7 @@ impl PopoverExampleContentView {
                 let Some(ref popover) = self.popover else { return };
                 let Some(ref button) = self.button else { return };
                 popover.show_popover(Rect::zero(), button, Edge::MaxY);
-            },
+            }
         }
     }
 }
@@ -149,7 +140,7 @@ impl ViewDelegate for PopoverExampleContentView {
 
         LayoutConstraint::activate(&[
             button.center_x.constraint_equal_to(&view.center_x),
-            button.center_y.constraint_equal_to(&view.center_y),
+            button.center_y.constraint_equal_to(&view.center_y)
         ]);
 
         self.view = Some(view);
@@ -175,7 +166,7 @@ impl Dispatcher for BasicApp {
 
 #[derive(Debug)]
 struct PopoverExampleContentViewController {
-    pub control: SegmentedControl,
+    pub control: SegmentedControl
 }
 
 impl PopoverExampleContentViewController {

--- a/examples/popover.rs
+++ b/examples/popover.rs
@@ -5,13 +5,15 @@
 //! - Another Controller / View
 
 use cacao::appkit::menu::{Menu, MenuItem};
+use cacao::appkit::segmentedcontrol::SegmentedControl;
 use cacao::appkit::window::{Window, WindowConfig, WindowController, WindowDelegate};
 use cacao::appkit::{App, AppDelegate};
 use cacao::button::Button;
+use cacao::foundation::NSArray;
 use cacao::geometry::{Edge, Rect};
+use cacao::image::Image;
 use cacao::layout::{Layout, LayoutConstraint};
 use cacao::notification_center::Dispatcher;
-use cacao::text::{Font, Label};
 use cacao::view::{Popover, PopoverConfig, View, ViewController, ViewDelegate};
 
 struct BasicApp {
@@ -133,7 +135,7 @@ impl ViewDelegate for PopoverExampleContentView {
 
     fn did_load(&mut self, view: cacao::view::View) {
         let mut button = Button::new("Show");
-        button.set_action(|| dispatch_ui(Msg::Click));
+        button.set_action(|_| dispatch_ui(Msg::Click));
 
         let controller = PopoverExampleContentViewController::new();
         let config = PopoverConfig {
@@ -173,16 +175,21 @@ impl Dispatcher for BasicApp {
 
 #[derive(Debug)]
 struct PopoverExampleContentViewController {
-    pub label: Label,
+    pub control: SegmentedControl,
 }
 
 impl PopoverExampleContentViewController {
     fn new() -> Self {
-        let label = Label::new();
-        let font = Font::system(20.);
-        label.set_font(&font);
-        label.set_text("Hello");
-        Self { label }
+        let images = NSArray::from(vec![
+            &*Image::symbol(cacao::image::SFSymbol::AtSymbol, "Hello").0,
+            &*Image::symbol(cacao::image::SFSymbol::PaperPlane, "Hello").0,
+            &*Image::symbol(cacao::image::SFSymbol::PaperPlaneFilled, "Hello").0,
+        ]);
+        let mut control = SegmentedControl::new(images, cacao::appkit::segmentedcontrol::TrackingMode::SelectOne);
+        control.set_action(|index| {
+            println!("Selected Index {index}");
+        });
+        Self { control }
     }
 }
 
@@ -190,6 +197,6 @@ impl ViewDelegate for PopoverExampleContentViewController {
     const NAME: &'static str = "PopoverExampleContentViewController";
 
     fn did_load(&mut self, view: View) {
-        view.add_subview(&self.label);
+        view.add_subview(&self.control);
     }
 }

--- a/examples/todos_list/add/view.rs
+++ b/examples/todos_list/add/view.rs
@@ -19,7 +19,7 @@ use crate::storage::{dispatch_ui, Message};
 pub struct AddNewTodoContentView {
     pub view: Option<View>,
     pub input: Option<TextField>,
-    pub button: Option<Button>
+    pub button: Option<Button>,
 }
 
 impl AddNewTodoContentView {
@@ -34,7 +34,7 @@ impl AddNewTodoContentView {
                 }
             },
 
-            _ => {}
+            _ => {},
         }
     }
 }
@@ -50,7 +50,7 @@ impl ViewDelegate for AddNewTodoContentView {
 
         let mut button = Button::new("Add");
         button.set_key_equivalent("\r");
-        button.set_action(|| dispatch_ui(Message::ProcessNewTodo));
+        button.set_action(|_| dispatch_ui(Message::ProcessNewTodo));
 
         view.add_subview(&instructions);
         view.add_subview(&input);
@@ -65,7 +65,7 @@ impl ViewDelegate for AddNewTodoContentView {
             input.trailing.constraint_equal_to(&view.trailing).offset(-16.),
             button.top.constraint_equal_to(&input.bottom).offset(8.),
             button.trailing.constraint_equal_to(&view.trailing).offset(-16.),
-            button.bottom.constraint_equal_to(&view.bottom).offset(-16.)
+            button.bottom.constraint_equal_to(&view.bottom).offset(-16.),
         ]);
 
         self.view = Some(view);

--- a/examples/todos_list/add/view.rs
+++ b/examples/todos_list/add/view.rs
@@ -19,7 +19,7 @@ use crate::storage::{dispatch_ui, Message};
 pub struct AddNewTodoContentView {
     pub view: Option<View>,
     pub input: Option<TextField>,
-    pub button: Option<Button>,
+    pub button: Option<Button>
 }
 
 impl AddNewTodoContentView {
@@ -34,7 +34,7 @@ impl AddNewTodoContentView {
                 }
             },
 
-            _ => {},
+            _ => {}
         }
     }
 }
@@ -65,7 +65,7 @@ impl ViewDelegate for AddNewTodoContentView {
             input.trailing.constraint_equal_to(&view.trailing).offset(-16.),
             button.top.constraint_equal_to(&input.bottom).offset(8.),
             button.trailing.constraint_equal_to(&view.trailing).offset(-16.),
-            button.bottom.constraint_equal_to(&view.bottom).offset(-16.),
+            button.bottom.constraint_equal_to(&view.bottom).offset(-16.)
         ]);
 
         self.view = Some(view);

--- a/examples/todos_list/preferences/toggle_option_view.rs
+++ b/examples/todos_list/preferences/toggle_option_view.rs
@@ -11,7 +11,7 @@ pub struct ToggleOptionView {
     pub view: View,
     pub switch: Switch,
     pub title: Label,
-    pub subtitle: Label,
+    pub subtitle: Label
 }
 
 impl Default for ToggleOptionView {
@@ -39,14 +39,14 @@ impl Default for ToggleOptionView {
             subtitle.leading.constraint_equal_to(&switch.trailing),
             subtitle.trailing.constraint_equal_to(&view.trailing),
             subtitle.bottom.constraint_equal_to(&view.bottom),
-            subtitle.width.constraint_greater_than_or_equal_to_constant(200.),
+            subtitle.width.constraint_greater_than_or_equal_to_constant(200.)
         ]);
 
         ToggleOptionView {
             view,
             switch,
             title,
-            subtitle,
+            subtitle
         }
     }
 }
@@ -56,7 +56,7 @@ impl ToggleOptionView {
     /// can toggle your settings and such there.
     pub fn configure<F>(&mut self, text: &str, subtitle: &str, state: bool, handler: F)
     where
-        F: Fn(*const Object) + Send + Sync + 'static,
+        F: Fn(*const Object) + Send + Sync + 'static
     {
         self.title.set_text(text);
         self.subtitle.set_text(subtitle);

--- a/examples/todos_list/preferences/toggle_option_view.rs
+++ b/examples/todos_list/preferences/toggle_option_view.rs
@@ -2,6 +2,7 @@ use cacao::layout::{Layout, LayoutConstraint};
 use cacao::switch::Switch;
 use cacao::text::Label;
 use cacao::view::View;
+use objc::runtime::Object;
 
 /// A reusable widget for a toggle; this is effectively a standard checkbox/label combination for
 /// toggling a boolean value.
@@ -10,7 +11,7 @@ pub struct ToggleOptionView {
     pub view: View,
     pub switch: Switch,
     pub title: Label,
-    pub subtitle: Label
+    pub subtitle: Label,
 }
 
 impl Default for ToggleOptionView {
@@ -38,14 +39,14 @@ impl Default for ToggleOptionView {
             subtitle.leading.constraint_equal_to(&switch.trailing),
             subtitle.trailing.constraint_equal_to(&view.trailing),
             subtitle.bottom.constraint_equal_to(&view.bottom),
-            subtitle.width.constraint_greater_than_or_equal_to_constant(200.)
+            subtitle.width.constraint_greater_than_or_equal_to_constant(200.),
         ]);
 
         ToggleOptionView {
             view,
             switch,
             title,
-            subtitle
+            subtitle,
         }
     }
 }
@@ -55,7 +56,7 @@ impl ToggleOptionView {
     /// can toggle your settings and such there.
     pub fn configure<F>(&mut self, text: &str, subtitle: &str, state: bool, handler: F)
     where
-        F: Fn() + Send + Sync + 'static
+        F: Fn(*const Object) + Send + Sync + 'static,
     {
         self.title.set_text(text);
         self.subtitle.set_text(subtitle);

--- a/examples/todos_list/preferences/toolbar.rs
+++ b/examples/todos_list/preferences/toolbar.rs
@@ -19,7 +19,7 @@ impl Default for PreferencesToolbar {
                 let icon = Image::toolbar_icon(MacSystemIcon::PreferencesGeneral, "General");
                 item.set_image(icon);
 
-                item.set_action(|| {
+                item.set_action(|_| {
                     dispatch_ui(Message::SwitchPreferencesToGeneralPane);
                 });
 
@@ -32,12 +32,12 @@ impl Default for PreferencesToolbar {
                 let icon = Image::toolbar_icon(MacSystemIcon::PreferencesAdvanced, "Advanced");
                 item.set_image(icon);
 
-                item.set_action(|| {
+                item.set_action(|_| {
                     dispatch_ui(Message::SwitchPreferencesToAdvancedPane);
                 });
 
                 item
-            }
+            },
         ))
     }
 }
@@ -67,7 +67,7 @@ impl ToolbarDelegate for PreferencesToolbar {
             "advanced" => &self.0 .1,
             _ => {
                 unreachable!();
-            }
+            },
         }
     }
 }

--- a/examples/todos_list/preferences/toolbar.rs
+++ b/examples/todos_list/preferences/toolbar.rs
@@ -37,7 +37,7 @@ impl Default for PreferencesToolbar {
                 });
 
                 item
-            },
+            }
         ))
     }
 }
@@ -67,7 +67,7 @@ impl ToolbarDelegate for PreferencesToolbar {
             "advanced" => &self.0 .1,
             _ => {
                 unreachable!();
-            },
+            }
         }
     }
 }

--- a/examples/todos_list/storage/defaults.rs
+++ b/examples/todos_list/storage/defaults.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use cacao::defaults::{UserDefaults, Value};
+use objc::runtime::Object;
 
 const EXAMPLE: &str = "exampleSetting";
 
@@ -25,7 +26,7 @@ impl Defaults {
     }
 
     /// Toggles the example setting.
-    pub fn toggle_should_whatever() {
+    pub fn toggle_should_whatever(_object: *const Object) {
         toggle_bool(EXAMPLE);
     }
 

--- a/examples/todos_list/todos/toolbar.rs
+++ b/examples/todos_list/todos/toolbar.rs
@@ -15,7 +15,7 @@ impl Default for TodosToolbar {
             item.set_title("Add Todo");
             item.set_button(Button::new("+ New"));
 
-            item.set_action(|| {
+            item.set_action(|_| {
                 dispatch_ui(Message::OpenNewTodoSheet);
             });
 

--- a/src/appkit/mod.rs
+++ b/src/appkit/mod.rs
@@ -27,3 +27,5 @@ pub mod menu;
 pub mod printing;
 pub mod toolbar;
 pub mod window;
+
+pub mod segmentedcontrol;

--- a/src/appkit/segmentedcontrol.rs
+++ b/src/appkit/segmentedcontrol.rs
@@ -42,7 +42,7 @@ use crate::appkit::FocusRingType;
 /// let mut button = Button::new("My button title");
 /// button.set_key_equivalent("c");
 ///
-/// button.set_action(|| {
+/// button.set_action(|_| {
 ///     println!("My button was clicked.");
 /// });
 /// let my_view : View<()> = todo!();

--- a/src/appkit/segmentedcontrol.rs
+++ b/src/appkit/segmentedcontrol.rs
@@ -98,7 +98,7 @@ pub struct SegmentedControl {
 
     /// A pointer to the Objective-C runtime center Y layout constraint.
     #[cfg(feature = "autolayout")]
-    pub center_y: LayoutAnchorY,
+    pub center_y: LayoutAnchorY
 }
 
 #[derive(Debug)]
@@ -106,7 +106,7 @@ pub struct SegmentedControl {
 pub enum TrackingMode {
     SelectOne = 0,
     SelectMany = 1,
-    SelectMomentary = 2,
+    SelectMomentary = 2
 }
 
 impl SegmentedControl {
@@ -163,7 +163,7 @@ impl SegmentedControl {
             #[cfg(feature = "autolayout")]
             center_y: LayoutAnchorY::center(view),
 
-            objc: ObjcProperty::retain(view),
+            objc: ObjcProperty::retain(view)
         }
     }
 
@@ -216,14 +216,14 @@ impl SegmentedControl {
     /// button will fire.
     pub fn set_key_equivalent<'a, K>(&self, key: K)
     where
-        K: Into<Key<'a>>,
+        K: Into<Key<'a>>
     {
         let key: Key<'a> = key.into();
 
         self.objc.with_mut(|obj| {
             let keychar = match key {
                 Key::Char(s) => NSString::new(s),
-                Key::Delete => NSString::new("\u{08}"),
+                Key::Delete => NSString::new("\u{08}")
             };
 
             unsafe {

--- a/src/appkit/toolbar/item.rs
+++ b/src/appkit/toolbar/item.rs
@@ -24,7 +24,7 @@ pub struct ToolbarItem {
     pub button: Option<Button>,
     pub segmented_control: Option<SegmentedControl>,
     pub image: Option<Image>,
-    handler: Option<TargetActionHandler>,
+    handler: Option<TargetActionHandler>
 }
 
 impl ToolbarItem {
@@ -46,7 +46,7 @@ impl ToolbarItem {
             button: None,
             segmented_control: None,
             image: None,
-            handler: None,
+            handler: None
         }
     }
 
@@ -57,7 +57,7 @@ impl ToolbarItem {
             button: None,
             segmented_control: None,
             image: None,
-            handler: None,
+            handler: None
         }
     }
 

--- a/src/appkit/toolbar/item.rs
+++ b/src/appkit/toolbar/item.rs
@@ -10,6 +10,7 @@ use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl};
 use objc_id::{Id, ShareId};
 
+use crate::appkit::segmentedcontrol::SegmentedControl;
 use crate::button::{BezelStyle, Button};
 use crate::foundation::{id, NSString, NO, YES};
 use crate::image::Image;
@@ -21,8 +22,9 @@ pub struct ToolbarItem {
     pub identifier: String,
     pub objc: Id<Object>,
     pub button: Option<Button>,
+    pub segmented_control: Option<SegmentedControl>,
     pub image: Option<Image>,
-    handler: Option<TargetActionHandler>
+    handler: Option<TargetActionHandler>,
 }
 
 impl ToolbarItem {
@@ -42,8 +44,9 @@ impl ToolbarItem {
             identifier,
             objc,
             button: None,
+            segmented_control: None,
             image: None,
-            handler: None
+            handler: None,
         }
     }
 
@@ -52,8 +55,9 @@ impl ToolbarItem {
             identifier: "".to_string(),
             objc: unsafe { Id::from_retained_ptr(item) },
             button: None,
+            segmented_control: None,
             image: None,
-            handler: None
+            handler: None,
         }
     }
 
@@ -74,6 +78,15 @@ impl ToolbarItem {
         });
 
         self.button = Some(button);
+    }
+
+    /// Sets and takes ownership of the segmented control for this item.
+    pub fn set_segmented_control(&mut self, control: SegmentedControl) {
+        control.objc.with_mut(|obj| unsafe {
+            let _: () = msg_send![&*self.objc, setView: obj];
+        });
+
+        self.segmented_control = Some(control);
     }
 
     /// Sets and takes ownership of the image for this toolbar item.
@@ -102,7 +115,7 @@ impl ToolbarItem {
     }
 
     /// Sets an action on this item.
-    pub fn set_action<F: Fn() + Send + Sync + 'static>(&mut self, action: F) {
+    pub fn set_action<F: Fn(*const Object) + Send + Sync + 'static>(&mut self, action: F) {
         let handler = TargetActionHandler::new(&*self.objc, action);
         self.handler = Some(handler);
     }

--- a/src/appkit/window/mod.rs
+++ b/src/appkit/window/mod.rs
@@ -50,7 +50,7 @@ pub struct Window<T = ()> {
     pub objc: ShareId<Object>,
 
     /// A delegate for this window.
-    pub delegate: Option<Box<T>>,
+    pub delegate: Option<Box<T>>
 }
 
 impl Default for Window {
@@ -124,7 +124,7 @@ impl Window {
 
 impl<T> Window<T>
 where
-    T: WindowDelegate + 'static,
+    T: WindowDelegate + 'static
 {
     /// Constructs a new Window with a `config` and `delegate`. Using a `WindowDelegate` enables
     /// you to respond to window lifecycle events - visibility, movement, and so on. It also
@@ -184,13 +184,13 @@ where
         {
             (&mut delegate).did_load(Window {
                 delegate: None,
-                objc: objc.clone(),
+                objc: objc.clone()
             });
         }
 
         Window {
             objc: objc,
-            delegate: Some(delegate),
+            delegate: Some(delegate)
         }
     }
 }
@@ -506,7 +506,7 @@ impl<T> Window<T> {
     pub fn begin_sheet<F, W>(&self, window: &Window<W>, completion: F)
     where
         F: Fn() + Send + Sync + 'static,
-        W: WindowDelegate + 'static,
+        W: WindowDelegate + 'static
     {
         let block = ConcreteBlock::new(move |_response: NSInteger| {
             completion();
@@ -521,7 +521,7 @@ impl<T> Window<T> {
     /// Closes a sheet.
     pub fn end_sheet<W>(&self, window: &Window<W>)
     where
-        W: WindowDelegate + 'static,
+        W: WindowDelegate + 'static
     {
         unsafe {
             let _: () = msg_send![&*self.objc, endSheet:&*window.objc];

--- a/src/appkit/window/mod.rs
+++ b/src/appkit/window/mod.rs
@@ -50,7 +50,7 @@ pub struct Window<T = ()> {
     pub objc: ShareId<Object>,
 
     /// A delegate for this window.
-    pub delegate: Option<Box<T>>
+    pub delegate: Option<Box<T>>,
 }
 
 impl Default for Window {
@@ -124,7 +124,7 @@ impl Window {
 
 impl<T> Window<T>
 where
-    T: WindowDelegate + 'static
+    T: WindowDelegate + 'static,
 {
     /// Constructs a new Window with a `config` and `delegate`. Using a `WindowDelegate` enables
     /// you to respond to window lifecycle events - visibility, movement, and so on. It also
@@ -184,13 +184,13 @@ where
         {
             (&mut delegate).did_load(Window {
                 delegate: None,
-                objc: objc.clone()
+                objc: objc.clone(),
             });
         }
 
         Window {
             objc: objc,
-            delegate: Some(delegate)
+            delegate: Some(delegate),
         }
     }
 }
@@ -280,11 +280,27 @@ impl<T> Window<T> {
         }
     }
 
+    /// Used for setting a toolbar on this window.
+    pub fn toolbar(&self) -> ShareId<Object> {
+        unsafe {
+            let o: *mut Object = msg_send![&*self.objc, toolbar];
+            ShareId::from_ptr(o)
+        }
+    }
+
     /// Toggles whether the toolbar is shown for this window. Has no effect if no toolbar exists on
     /// this window.
     pub fn toggle_toolbar_shown(&self) {
         unsafe {
             let _: () = msg_send![&*self.objc, toggleToolbarShown: nil];
+        }
+    }
+
+    /// Set the toolbar style
+    pub fn set_toolbar_style(&self, style: WindowToolbarStyle) {
+        let style: NSUInteger = style.into();
+        unsafe {
+            let _: () = msg_send![&*self.objc, setToolbarStyle: style];
         }
     }
 
@@ -475,7 +491,7 @@ impl<T> Window<T> {
     pub fn begin_sheet<F, W>(&self, window: &Window<W>, completion: F)
     where
         F: Fn() + Send + Sync + 'static,
-        W: WindowDelegate + 'static
+        W: WindowDelegate + 'static,
     {
         let block = ConcreteBlock::new(move |_response: NSInteger| {
             completion();
@@ -490,7 +506,7 @@ impl<T> Window<T> {
     /// Closes a sheet.
     pub fn end_sheet<W>(&self, window: &Window<W>)
     where
-        W: WindowDelegate + 'static
+        W: WindowDelegate + 'static,
     {
         unsafe {
             let _: () = msg_send![&*self.objc, endSheet:&*window.objc];

--- a/src/button/mod.rs
+++ b/src/button/mod.rs
@@ -12,7 +12,7 @@
 //! let mut button = Button::new("My button title");
 //! button.set_key_equivalent("c");
 //!
-//! button.set_action(|| {
+//! button.set_action(|_| {
 //!     println!("My button was clicked.");
 //! });
 //! let my_view : View<()> = todo!();
@@ -66,7 +66,7 @@ pub use enums::*;
 /// let mut button = Button::new("My button title");
 /// button.set_key_equivalent("c");
 ///
-/// button.set_action(|| {
+/// button.set_action(|_| {
 ///     println!("My button was clicked.");
 /// });
 /// let my_view : View<()> = todo!();

--- a/src/button/mod.rs
+++ b/src/button/mod.rs
@@ -114,7 +114,7 @@ pub struct Button {
 
     /// A pointer to the Objective-C runtime center Y layout constraint.
     #[cfg(feature = "autolayout")]
-    pub center_y: LayoutAnchorY,
+    pub center_y: LayoutAnchorY
 }
 
 impl Button {
@@ -171,7 +171,7 @@ impl Button {
             #[cfg(feature = "autolayout")]
             center_y: LayoutAnchorY::center(view),
 
-            objc: ObjcProperty::retain(view),
+            objc: ObjcProperty::retain(view)
         }
     }
 
@@ -234,14 +234,14 @@ impl Button {
     /// button will fire.
     pub fn set_key_equivalent<'a, K>(&self, key: K)
     where
-        K: Into<Key<'a>>,
+        K: Into<Key<'a>>
     {
         let key: Key<'a> = key.into();
 
         self.objc.with_mut(|obj| {
             let keychar = match key {
                 Key::Char(s) => NSString::new(s),
-                Key::Delete => NSString::new("\u{08}"),
+                Key::Delete => NSString::new("\u{08}")
             };
 
             unsafe {

--- a/src/image/icons.rs
+++ b/src/image/icons.rs
@@ -30,7 +30,7 @@ pub enum MacSystemIcon {
     Remove,
 
     /// Returns a Folder icon.
-    Folder,
+    Folder
 }
 
 extern "C" {
@@ -53,7 +53,7 @@ impl MacSystemIcon {
                 MacSystemIcon::PreferencesUserAccounts => NSImageNameUserAccounts,
                 MacSystemIcon::Add => NSImageNameAddTemplate,
                 MacSystemIcon::Remove => NSImageNameRemoveTemplate,
-                MacSystemIcon::Folder => NSImageNameFolder,
+                MacSystemIcon::Folder => NSImageNameFolder
             }
         }
     }
@@ -66,7 +66,7 @@ impl MacSystemIcon {
             MacSystemIcon::PreferencesUserAccounts => SFSymbol::AtSymbol.to_str(),
             MacSystemIcon::Add => SFSymbol::Plus.to_str(),
             MacSystemIcon::Remove => SFSymbol::Minus.to_str(),
-            MacSystemIcon::Folder => SFSymbol::FolderFilled.to_str(),
+            MacSystemIcon::Folder => SFSymbol::FolderFilled.to_str()
         }
     }
 }
@@ -98,7 +98,7 @@ pub enum SFSymbol {
     SquareAndArrowDownOnSquare,
     SquareAndArrowDownOnSquareFill,
     SquareDashed,
-    SquareAndPencil,
+    SquareAndPencil
 }
 
 impl SFSymbol {
@@ -129,7 +129,7 @@ impl SFSymbol {
             Self::SquareAndArrowDownOnSquare => "square.and.arrow.down.on.square",
             Self::SquareAndArrowDownOnSquareFill => "square.and.arrow.down.on.square.fill",
             Self::SquareDashed => "square.dashed",
-            Self::SquareAndPencil => "square.and.pencil",
+            Self::SquareAndPencil => "square.and.pencil"
         }
     }
 }

--- a/src/image/icons.rs
+++ b/src/image/icons.rs
@@ -30,7 +30,7 @@ pub enum MacSystemIcon {
     Remove,
 
     /// Returns a Folder icon.
-    Folder
+    Folder,
 }
 
 extern "C" {
@@ -53,7 +53,7 @@ impl MacSystemIcon {
                 MacSystemIcon::PreferencesUserAccounts => NSImageNameUserAccounts,
                 MacSystemIcon::Add => NSImageNameAddTemplate,
                 MacSystemIcon::Remove => NSImageNameRemoveTemplate,
-                MacSystemIcon::Folder => NSImageNameFolder
+                MacSystemIcon::Folder => NSImageNameFolder,
             }
         }
     }
@@ -66,7 +66,7 @@ impl MacSystemIcon {
             MacSystemIcon::PreferencesUserAccounts => SFSymbol::AtSymbol.to_str(),
             MacSystemIcon::Add => SFSymbol::Plus.to_str(),
             MacSystemIcon::Remove => SFSymbol::Minus.to_str(),
-            MacSystemIcon::Folder => SFSymbol::FolderFilled.to_str()
+            MacSystemIcon::Folder => SFSymbol::FolderFilled.to_str(),
         }
     }
 }
@@ -74,36 +74,62 @@ impl MacSystemIcon {
 #[derive(Debug)]
 pub enum SFSymbol {
     AtSymbol,
+    ArrowClockwise,
+    Bell,
+    BellFill,
+    BellBadge,
+    BellBadgeFill,
     GearShape,
     FolderFilled,
+    ListAndFilm,
     PaperPlane,
     PaperPlaneFilled,
     Plus,
     Minus,
+    Message,
+    MessageFill,
+    MessageBadge,
+    MessageBadgeFill,
+    MessageBadgeFilledFill,
+    PersonCropCircle,
     SliderVertical3,
     SquareAndArrowUpOnSquare,
     SquareAndArrowUpOnSquareFill,
     SquareAndArrowDownOnSquare,
     SquareAndArrowDownOnSquareFill,
-    SquareDashed
+    SquareDashed,
+    SquareAndPencil,
 }
 
 impl SFSymbol {
     pub fn to_str(&self) -> &'static str {
         match self {
             Self::AtSymbol => "at",
+            Self::ArrowClockwise => "arrow.clockwise",
             Self::GearShape => "gearshape",
             Self::FolderFilled => "folder.fill",
+            Self::ListAndFilm => "list.and.film",
+            Self::Bell => "bell",
+            Self::BellFill => "bell.fill",
+            Self::BellBadge => "bell.badge",
+            Self::BellBadgeFill => "bell.badge.fill",
             Self::PaperPlane => "paperplane",
             Self::PaperPlaneFilled => "paperplane.fill",
             Self::Plus => "plus",
             Self::Minus => "minus",
+            Self::Message => "message",
+            Self::MessageFill => "message.fill",
+            Self::MessageBadge => "message.badge",
+            Self::MessageBadgeFill => "message.badge.fill",
+            Self::MessageBadgeFilledFill => "message.badge.filled.fill",
+            Self::PersonCropCircle => "person.crop.circle",
             Self::SliderVertical3 => "slider.vertical.3",
             Self::SquareAndArrowUpOnSquare => "square.and.arrow.up.on.square",
             Self::SquareAndArrowUpOnSquareFill => "square.and.arrow.up.on.square.fill",
             Self::SquareAndArrowDownOnSquare => "square.and.arrow.down.on.square",
             Self::SquareAndArrowDownOnSquareFill => "square.and.arrow.down.on.square.fill",
-            Self::SquareDashed => "square.dashed"
+            Self::SquareDashed => "square.dashed",
+            Self::SquareAndPencil => "square.and.pencil",
         }
     }
 }

--- a/src/image/image.rs
+++ b/src/image/image.rs
@@ -8,11 +8,11 @@ use block::ConcreteBlock;
 use core_graphics::context::{CGContext, CGContextRef};
 use core_graphics::{
     base::CGFloat,
-    geometry::{CGPoint, CGRect, CGSize}
+    geometry::{CGPoint, CGRect, CGSize},
 };
 
 use super::icons::*;
-use crate::foundation::{id, NSData, NSString, NO, YES};
+use crate::foundation::{id, NSData, NSString, NO, NSURL, YES};
 use crate::utils::os;
 
 /// Specifies resizing behavior for image drawing.
@@ -28,7 +28,7 @@ pub enum ResizeBehavior {
     Stretch,
 
     /// Center and then let whatever else flow around it.
-    Center
+    Center,
 }
 
 fn max_cgfloat(x: CGFloat, y: CGFloat) -> CGFloat {
@@ -38,7 +38,7 @@ fn max_cgfloat(x: CGFloat, y: CGFloat) -> CGFloat {
 
     match x > y {
         true => x,
-        false => y
+        false => y,
     }
 }
 
@@ -49,7 +49,7 @@ fn min_cgfloat(x: CGFloat, y: CGFloat) -> CGFloat {
 
     match x < y {
         true => x,
-        false => y
+        false => y,
     }
 }
 
@@ -90,7 +90,7 @@ impl ResizeBehavior {
             ResizeBehavior::Center => {
                 scales.width = 1.;
                 scales.height = 1.;
-            }
+            },
         }
 
         let mut result = source;
@@ -113,7 +113,7 @@ pub struct DrawConfig {
     pub target: (CGFloat, CGFloat),
 
     /// The type of resizing to use during drawing and scaling.
-    pub resize: ResizeBehavior
+    pub resize: ResizeBehavior,
 }
 
 /// Wraps `NSImage` under AppKit, and `UIImage` on under UIKit (iOS and tvOS). Can be used to display images, icons,
@@ -143,6 +143,14 @@ impl Image {
         Image(unsafe {
             let alloc: id = msg_send![Self::class(), alloc];
             ShareId::from_ptr(msg_send![alloc, initWithContentsOfFile: file_path])
+        })
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn with_contents_of_url(url: NSURL) -> Self {
+        Image(unsafe {
+            let alloc: id = msg_send![Self::class(), alloc];
+            ShareId::from_ptr(msg_send![alloc, initWithContentsOfURL: url.objc])
         })
     }
 
@@ -195,7 +203,7 @@ impl Image {
                 false => {
                     let icon = icon.to_id();
                     msg_send![Self::class(), imageNamed: icon]
-                }
+                },
             })
         })
     }
@@ -232,7 +240,7 @@ impl Image {
 
                     #[cfg(all(feature = "uikit", not(feature = "appkit")))]
                     panic!("SFSymbols are only supported on macOS 11.0 and up.");
-                }
+                },
             })
         })
     }
@@ -244,7 +252,7 @@ impl Image {
     #[cfg(feature = "appkit")]
     pub fn draw<F>(config: DrawConfig, handler: F) -> Self
     where
-        F: Fn(CGRect, &CGContextRef) -> bool + 'static
+        F: Fn(CGRect, &CGContextRef) -> bool + 'static,
     {
         let source_frame = CGRect::new(&CGPoint::new(0., 0.), &CGSize::new(config.source.0, config.source.1));
 
@@ -261,7 +269,7 @@ impl Image {
             context.translate(resized_frame.origin.x, resized_frame.origin.y);
             context.scale(
                 resized_frame.size.width / config.source.0,
-                resized_frame.size.height / config.source.1
+                resized_frame.size.height / config.source.1,
             );
 
             let result = handler(resized_frame, &context);
@@ -270,7 +278,7 @@ impl Image {
 
             match result {
                 true => YES,
-                false => NO
+                false => NO,
             }
         });
         let block = block.copy();

--- a/src/image/image.rs
+++ b/src/image/image.rs
@@ -8,7 +8,7 @@ use block::ConcreteBlock;
 use core_graphics::context::{CGContext, CGContextRef};
 use core_graphics::{
     base::CGFloat,
-    geometry::{CGPoint, CGRect, CGSize},
+    geometry::{CGPoint, CGRect, CGSize}
 };
 
 use super::icons::*;
@@ -28,7 +28,7 @@ pub enum ResizeBehavior {
     Stretch,
 
     /// Center and then let whatever else flow around it.
-    Center,
+    Center
 }
 
 fn max_cgfloat(x: CGFloat, y: CGFloat) -> CGFloat {
@@ -38,7 +38,7 @@ fn max_cgfloat(x: CGFloat, y: CGFloat) -> CGFloat {
 
     match x > y {
         true => x,
-        false => y,
+        false => y
     }
 }
 
@@ -49,7 +49,7 @@ fn min_cgfloat(x: CGFloat, y: CGFloat) -> CGFloat {
 
     match x < y {
         true => x,
-        false => y,
+        false => y
     }
 }
 
@@ -90,7 +90,7 @@ impl ResizeBehavior {
             ResizeBehavior::Center => {
                 scales.width = 1.;
                 scales.height = 1.;
-            },
+            }
         }
 
         let mut result = source;
@@ -113,7 +113,7 @@ pub struct DrawConfig {
     pub target: (CGFloat, CGFloat),
 
     /// The type of resizing to use during drawing and scaling.
-    pub resize: ResizeBehavior,
+    pub resize: ResizeBehavior
 }
 
 /// Wraps `NSImage` under AppKit, and `UIImage` on under UIKit (iOS and tvOS). Can be used to display images, icons,
@@ -203,7 +203,7 @@ impl Image {
                 false => {
                     let icon = icon.to_id();
                     msg_send![Self::class(), imageNamed: icon]
-                },
+                }
             })
         })
     }
@@ -240,7 +240,7 @@ impl Image {
 
                     #[cfg(all(feature = "uikit", not(feature = "appkit")))]
                     panic!("SFSymbols are only supported on macOS 11.0 and up.");
-                },
+                }
             })
         })
     }
@@ -252,7 +252,7 @@ impl Image {
     #[cfg(feature = "appkit")]
     pub fn draw<F>(config: DrawConfig, handler: F) -> Self
     where
-        F: Fn(CGRect, &CGContextRef) -> bool + 'static,
+        F: Fn(CGRect, &CGContextRef) -> bool + 'static
     {
         let source_frame = CGRect::new(&CGPoint::new(0., 0.), &CGSize::new(config.source.0, config.source.1));
 
@@ -269,7 +269,7 @@ impl Image {
             context.translate(resized_frame.origin.x, resized_frame.origin.y);
             context.scale(
                 resized_frame.size.width / config.source.0,
-                resized_frame.size.height / config.source.1,
+                resized_frame.size.height / config.source.1
             );
 
             let result = handler(resized_frame, &context);
@@ -278,7 +278,7 @@ impl Image {
 
             match result {
                 true => YES,
-                false => NO,
+                false => NO
             }
         });
         let block = block.copy();

--- a/src/invoker.rs
+++ b/src/invoker.rs
@@ -46,7 +46,7 @@ impl fmt::Debug for Action {
 #[derive(Debug)]
 pub struct TargetActionHandler {
     action: Box<Action>,
-    invoker: ShareId<Object>,
+    invoker: ShareId<Object>
 }
 
 impl TargetActionHandler {
@@ -68,7 +68,7 @@ impl TargetActionHandler {
 
         TargetActionHandler {
             invoker: invoker,
-            action: unsafe { Box::from_raw(ptr) },
+            action: unsafe { Box::from_raw(ptr) }
         }
     }
 }

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -78,7 +78,7 @@ pub struct Select {
 
     /// A pointer to the Objective-C runtime center Y layout constraint.
     #[cfg(feature = "autolayout")]
-    pub center_y: LayoutAnchorY,
+    pub center_y: LayoutAnchorY
 }
 
 impl Select {
@@ -130,7 +130,7 @@ impl Select {
             #[cfg(feature = "autolayout")]
             center_y: LayoutAnchorY::center(view),
 
-            objc: ObjcProperty::retain(view),
+            objc: ObjcProperty::retain(view)
         }
     }
 

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -83,7 +83,7 @@ pub struct Select {
 
     /// A pointer to the Objective-C runtime center Y layout constraint.
     #[cfg(feature = "autolayout")]
-    pub center_y: LayoutAnchorY
+    pub center_y: LayoutAnchorY,
 }
 
 impl Select {
@@ -135,7 +135,7 @@ impl Select {
             #[cfg(feature = "autolayout")]
             center_y: LayoutAnchorY::center(view),
 
-            objc: ObjcProperty::retain(view)
+            objc: ObjcProperty::retain(view),
         }
     }
 
@@ -145,7 +145,7 @@ impl Select {
     /// Really, this is not ideal.
     ///
     /// I cannot stress this enough.
-    pub fn set_action<F: Fn() + Send + Sync + 'static>(&mut self, action: F) {
+    pub fn set_action<F: Fn(*const Object) + Send + Sync + 'static>(&mut self, action: F) {
         // @TODO: This probably isn't ideal but gets the job done for now; needs revisiting.
         let this = self.objc.get(|obj| unsafe { ShareId::from_ptr(msg_send![obj, self]) });
         let handler = TargetActionHandler::new(&*this, action);

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -59,7 +59,7 @@ pub struct Switch {
 
     /// A pointer to the Objective-C runtime center Y layout constraint.
     #[cfg(feature = "autolayout")]
-    pub center_y: LayoutAnchorY,
+    pub center_y: LayoutAnchorY
 }
 
 impl Switch {
@@ -112,7 +112,7 @@ impl Switch {
             center_x: LayoutAnchorX::center(view),
 
             #[cfg(feature = "autolayout")]
-            center_y: LayoutAnchorY::center(view),
+            center_y: LayoutAnchorY::center(view)
         }
     }
 

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -64,7 +64,7 @@ pub struct Switch {
 
     /// A pointer to the Objective-C runtime center Y layout constraint.
     #[cfg(feature = "autolayout")]
-    pub center_y: LayoutAnchorY
+    pub center_y: LayoutAnchorY,
 }
 
 impl Switch {
@@ -117,7 +117,7 @@ impl Switch {
             center_x: LayoutAnchorX::center(view),
 
             #[cfg(feature = "autolayout")]
-            center_y: LayoutAnchorY::center(view)
+            center_y: LayoutAnchorY::center(view),
         }
     }
 
@@ -135,7 +135,7 @@ impl Switch {
 
     /// Attaches a callback for button press events. Don't get too creative now...
     /// best just to message pass or something.
-    pub fn set_action<F: Fn() + Send + Sync + 'static>(&mut self, action: F) {
+    pub fn set_action<F: Fn(*const Object) + Send + Sync + 'static>(&mut self, action: F) {
         // @TODO: This probably isn't ideal but gets the job done for now; needs revisiting.
         let this = self.objc.get(|obj| unsafe { ShareId::from_ptr(msg_send![obj, self]) });
         let handler = TargetActionHandler::new(&*this, action);


### PR DESCRIPTION
This PR contains a couple of changes:

## Segmented Control

This adds a segmented control. In order to know which index was selected (crucial to do something useful) I had to extend `set_action` to also receive an object (`*const Object`) which can then be inspected:

``` rs
       let mut control = SegmentedControl::new(images, cacao::appkit::segmentedcontrol::TrackingMode::SelectOne);
        control.set_action(|index| {
            println!("Selected Index {index}");
        });
```

This is a bit of a pervasive change that goes through the whole codebase

## Formatting

I'm using the default Rust Analysers auto formatting rules in all my code and somehow my settings are different than the one used in this codebase, so it added a lot of commas in places. I'm not sure if this is a problem for you or not. 

## Various

- Support for SegmentedControl in Toolbar
- Added more SFSymbols 
- Support loading images from URLs
