### PR TITLE
Global NSEvent listener and some mouse methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default-target = "x86_64-apple-darwin"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+bitmask-enum = "2.2.1"
 block = "0.1.6"
 core-foundation = "0.9"
 core-graphics = "0.23"

--- a/src/appkit/event/mod.rs
+++ b/src/appkit/event/mod.rs
@@ -48,7 +48,7 @@ pub enum EventMask {
     Pressure = 1 << 34,
     DirectTouch = 1 << 37,
 
-    ChangeMode = 1 << 38,
+    ChangeMode = 1 << 38
 }
 
 /// A wrapper over an `NSEvent`.
@@ -124,14 +124,14 @@ impl Event {
     /// monitors are required - the streams don't mix.
     pub fn local_monitor<F>(mask: EventMask, handler: F) -> EventMonitor
     where
-        F: Fn(Event) -> Option<Event> + Send + Sync + 'static,
+        F: Fn(Event) -> Option<Event> + Send + Sync + 'static
     {
         let block = ConcreteBlock::new(move |event: id| {
             let evt = Event::new(event);
 
             match handler(evt) {
                 Some(mut evt) => &mut *evt.0,
-                None => nil,
+                None => nil
             }
         });
         let block = block.copy();
@@ -150,14 +150,14 @@ impl Event {
     /// monitors are required - the streams don't mix.
     pub fn global_monitor<F>(mask: EventMask, handler: F) -> EventMonitor
     where
-        F: Fn(Event) -> Option<Event> + Send + Sync + 'static,
+        F: Fn(Event) -> Option<Event> + Send + Sync + 'static
     {
         let block = ConcreteBlock::new(move |event: id| {
             let evt = Event::new(event);
 
             match handler(evt) {
                 Some(mut evt) => &mut *evt.0,
-                None => nil,
+                None => nil
             }
         });
         let block = block.copy();
@@ -177,7 +177,7 @@ pub enum EventModifierFlag {
     Control,
     Option,
     Command,
-    DeviceIndependentFlagsMask,
+    DeviceIndependentFlagsMask
 }
 
 impl From<EventModifierFlag> for NSUInteger {
@@ -187,7 +187,7 @@ impl From<EventModifierFlag> for NSUInteger {
             EventModifierFlag::Control => 1 << 18,
             EventModifierFlag::Option => 1 << 19,
             EventModifierFlag::Command => 1 << 20,
-            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000,
+            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000
         }
     }
 }
@@ -199,7 +199,7 @@ impl From<&EventModifierFlag> for NSUInteger {
             EventModifierFlag::Control => 1 << 18,
             EventModifierFlag::Option => 1 << 19,
             EventModifierFlag::Command => 1 << 20,
-            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000,
+            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000
         }
     }
 }

--- a/src/appkit/event/mod.rs
+++ b/src/appkit/event/mod.rs
@@ -67,7 +67,7 @@ impl Event {
     /// The event's type.
     ///
     /// Corresponds to the `type` getter.
-    pub fn event_type(&self) -> EventType {
+    pub fn kind(&self) -> EventType {
         let kind: NSUInteger = unsafe { msg_send![&*self.0, type] };
 
         unsafe { ::std::mem::transmute(kind) }

--- a/src/appkit/event/mod.rs
+++ b/src/appkit/event/mod.rs
@@ -6,7 +6,7 @@ use objc::{class, msg_send, sel, sel_impl};
 use objc_id::Id;
 
 use crate::events::EventType;
-use crate::foundation::{id, nil, NSString};
+use crate::foundation::{id, nil, NSInteger, NSPoint, NSString};
 
 /// An EventMask describes the type of event.
 #[bitmask(u64)]
@@ -64,13 +64,16 @@ impl Event {
         Event(unsafe { Id::from_ptr(objc) })
     }
 
-    /// Corresponds to the `type` getter
+    /// The event's type.
+    ///
+    /// Corresponds to the `type` getter.
     pub fn event_type(&self) -> EventType {
         let kind: NSUInteger = unsafe { msg_send![&*self.0, type] };
 
         unsafe { ::std::mem::transmute(kind) }
     }
 
+    /// The characters associated with a key-up or key-down event.
     pub fn characters(&self) -> String {
         // @TODO: Check here if key event, invalid otherwise.
         // @TODO: Figure out if we can just return &str here, since the Objective-C side
@@ -78,6 +81,26 @@ impl Event {
         let characters = NSString::retain(unsafe { msg_send![&*self.0, characters] });
 
         characters.to_string()
+    }
+
+    /// The indices of the currently pressed mouse buttons.
+    pub fn pressed_mouse_buttons() -> NSUInteger {
+        unsafe { msg_send![class!(NSEvent), pressedMouseButtons] }
+    }
+
+    /// Reports the current mouse position in screen coordinates.
+    pub fn mouse_location() -> NSPoint {
+        unsafe { msg_send![class!(NSEvent), mouseLocation] }
+    }
+
+    /// The button number for a mouse event.
+    pub fn button_number(&self) -> NSInteger {
+        unsafe { msg_send![&*self.0, buttonNumber] }
+    }
+
+    /// The number of mouse clicks associated with a mouse-down or mouse-up event.
+    pub fn click_count(&self) -> NSInteger {
+        unsafe { msg_send![&*self.0, clickCount] }
     }
 
     /*pub fn contains_modifier_flags(&self, flags: &[EventModifierFlag]) -> bool {

--- a/src/appkit/event/mod.rs
+++ b/src/appkit/event/mod.rs
@@ -1,15 +1,54 @@
+use bitmask_enum::bitmask;
 use block::ConcreteBlock;
 
 use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl};
 use objc_id::Id;
 
+use crate::events::EventType;
 use crate::foundation::{id, nil, NSString};
 
 /// An EventMask describes the type of event.
-#[derive(Debug)]
+#[bitmask(u64)]
 pub enum EventMask {
-    KeyDown
+    LeftMouseDown = 1 << 1,
+    LeftMouseUp = 1 << 2,
+    RightMouseDown = 1 << 3,
+    RightMouseUp = 1 << 4,
+    MouseMoved = 1 << 5,
+    LeftMouseDragged = 1 << 6,
+    RightMouseDragged = 1 << 7,
+    MouseEntered = 1 << 8,
+    MouseExited = 1 << 9,
+    KeyDown = 1 << 10,
+    KeyUp = 1 << 11,
+    FlagsChanged = 1 << 12,
+    AppKitDefined = 1 << 13,
+    SystemDefined = 1 << 14,
+    ApplicationDefined = 1 << 15,
+    Periodic = 1 << 16,
+    CursorUpdate = 1 << 17,
+
+    ScrollWheel = 1 << 22,
+    TabletPoint = 1 << 23,
+    TabletProximity = 1 << 24,
+    OtherMouseDown = 1 << 25,
+    OtherMouseUp = 1 << 26,
+    OtherMouseDragged = 1 << 27,
+
+    Gesture = 1 << 29,
+    Magnify = 1 << 30,
+    Swipe = 1 << 31,
+    Rotate = 1 << 18,
+    BeginGesture = 1 << 19,
+    EndGesture = 1 << 20,
+
+    SmartMagnify = 1 << 32,
+    QuickLook = 1 << 33,
+    Pressure = 1 << 34,
+    DirectTouch = 1 << 37,
+
+    ChangeMode = 1 << 38,
 }
 
 /// A wrapper over an `NSEvent`.
@@ -23,6 +62,13 @@ pub struct Event(pub Id<Object>);
 impl Event {
     pub(crate) fn new(objc: id) -> Self {
         Event(unsafe { Id::from_ptr(objc) })
+    }
+
+    /// Corresponds to the `type` getter
+    pub fn event_type(&self) -> EventType {
+        let kind: NSUInteger = unsafe { msg_send![&*self.0, type] };
+
+        unsafe { ::std::mem::transmute(kind) }
     }
 
     pub fn characters(&self) -> String {
@@ -47,28 +93,54 @@ impl Event {
         false
     }*/
 
-    /// Register an event handler with the system event stream. This method
+    /// Register an event handler with the local system event stream. This method
     /// watches for events that occur _within the application_. Events outside
-    /// of the application require installing a `monitor_global_events` handler.
+    /// of the application require installing a `global_monitor` handler.
     ///
     /// Note that in order to monitor all possible events, both local and global
     /// monitors are required - the streams don't mix.
-    pub fn local_monitor<F>(_mask: EventMask, handler: F) -> EventMonitor
+    pub fn local_monitor<F>(mask: EventMask, handler: F) -> EventMonitor
     where
-        F: Fn(Event) -> Option<Event> + Send + Sync + 'static
+        F: Fn(Event) -> Option<Event> + Send + Sync + 'static,
     {
         let block = ConcreteBlock::new(move |event: id| {
             let evt = Event::new(event);
 
             match handler(evt) {
                 Some(mut evt) => &mut *evt.0,
-                None => nil
+                None => nil,
             }
         });
         let block = block.copy();
 
         EventMonitor(unsafe {
-            msg_send![class!(NSEvent), addLocalMonitorForEventsMatchingMask:1024
+            msg_send![class!(NSEvent), addLocalMonitorForEventsMatchingMask:mask.bits
+                handler:block]
+        })
+    }
+
+    /// Register an event handler with the global system event stream. This method
+    /// watches for events that occur _outside the application_. Events within
+    /// the application require installing a `local_monitor` handler.
+    ///
+    /// Note that in order to monitor all possible events, both local and global
+    /// monitors are required - the streams don't mix.
+    pub fn global_monitor<F>(mask: EventMask, handler: F) -> EventMonitor
+    where
+        F: Fn(Event) -> Option<Event> + Send + Sync + 'static,
+    {
+        let block = ConcreteBlock::new(move |event: id| {
+            let evt = Event::new(event);
+
+            match handler(evt) {
+                Some(mut evt) => &mut *evt.0,
+                None => nil,
+            }
+        });
+        let block = block.copy();
+
+        EventMonitor(unsafe {
+            msg_send![class!(NSEvent), addGlobalMonitorForEventsMatchingMask:mask.bits
                 handler:block]
         })
     }
@@ -82,7 +154,7 @@ pub enum EventModifierFlag {
     Control,
     Option,
     Command,
-    DeviceIndependentFlagsMask
+    DeviceIndependentFlagsMask,
 }
 
 impl From<EventModifierFlag> for NSUInteger {
@@ -92,7 +164,7 @@ impl From<EventModifierFlag> for NSUInteger {
             EventModifierFlag::Control => 1 << 18,
             EventModifierFlag::Option => 1 << 19,
             EventModifierFlag::Command => 1 << 20,
-            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000
+            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000,
         }
     }
 }
@@ -104,7 +176,7 @@ impl From<&EventModifierFlag> for NSUInteger {
             EventModifierFlag::Control => 1 << 18,
             EventModifierFlag::Option => 1 << 19,
             EventModifierFlag::Command => 1 << 20,
-            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000
+            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000,
         }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -19,7 +19,7 @@ pub enum EventModifierFlag {
     Command,
 
     /// Device independent flags mask.
-    DeviceIndependentFlagsMask
+    DeviceIndependentFlagsMask,
 }
 
 impl From<EventModifierFlag> for NSUInteger {
@@ -29,7 +29,7 @@ impl From<EventModifierFlag> for NSUInteger {
             EventModifierFlag::Control => 1 << 18,
             EventModifierFlag::Option => 1 << 19,
             EventModifierFlag::Command => 1 << 20,
-            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000
+            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000,
         }
     }
 }
@@ -41,14 +41,52 @@ impl From<&EventModifierFlag> for NSUInteger {
             EventModifierFlag::Control => 1 << 18,
             EventModifierFlag::Option => 1 << 19,
             EventModifierFlag::Command => 1 << 20,
-            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000
+            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000,
         }
     }
 }
 
 /// Represents an event type that you can request to be notified about.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(target_pointer_width = "32", repr(u32))]
+#[cfg_attr(target_pointer_width = "64", repr(u64))]
 pub enum EventType {
-    /// A keydown event.
-    KeyDown
+    LeftMouseDown = 1,
+    LeftMouseUp = 2,
+    RightMouseDown = 3,
+    RightMouseUp = 4,
+    MouseMoved = 5,
+    LeftMouseDragged = 6,
+    RightMouseDragged = 7,
+    MouseEntered = 8,
+    MouseExited = 9,
+    KeyDown = 10,
+    KeyUp = 11,
+    FlagsChanged = 12,
+    AppKitDefined = 13,
+    SystemDefined = 14,
+    ApplicationDefined = 15,
+    Periodic = 16,
+    CursorUpdate = 17,
+
+    ScrollWheel = 22,
+    TabletPoint = 23,
+    TabletProximity = 24,
+    OtherMouseDown = 25,
+    OtherMouseUp = 26,
+    OtherMouseDragged = 27,
+
+    Gesture = 29,
+    Magnify = 30,
+    Swipe = 31,
+    Rotate = 18,
+    BeginGesture = 19,
+    EndGesture = 20,
+
+    SmartMagnify = 32,
+    QuickLook = 33,
+    Pressure = 34,
+    DirectTouch = 37,
+
+    ChangeMode = 38,
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -19,7 +19,7 @@ pub enum EventModifierFlag {
     Command,
 
     /// Device independent flags mask.
-    DeviceIndependentFlagsMask,
+    DeviceIndependentFlagsMask
 }
 
 impl From<EventModifierFlag> for NSUInteger {
@@ -29,7 +29,7 @@ impl From<EventModifierFlag> for NSUInteger {
             EventModifierFlag::Control => 1 << 18,
             EventModifierFlag::Option => 1 << 19,
             EventModifierFlag::Command => 1 << 20,
-            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000,
+            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000
         }
     }
 }
@@ -41,7 +41,7 @@ impl From<&EventModifierFlag> for NSUInteger {
             EventModifierFlag::Control => 1 << 18,
             EventModifierFlag::Option => 1 << 19,
             EventModifierFlag::Command => 1 << 20,
-            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000,
+            EventModifierFlag::DeviceIndependentFlagsMask => 0xffff0000
         }
     }
 }
@@ -88,5 +88,5 @@ pub enum EventType {
     Pressure = 34,
     DirectTouch = 37,
 
-    ChangeMode = 38,
+    ChangeMode = 38
 }

--- a/src/foundation/mod.rs
+++ b/src/foundation/mod.rs
@@ -59,7 +59,7 @@ pub fn to_bool(result: BOOL) -> bool {
         #[cfg(not(target_arch = "aarch64"))]
         _ => {
             std::unreachable!();
-        }
+        },
     }
 }
 
@@ -86,3 +86,5 @@ pub type NSInteger = libc::c_long;
 /// Platform-specific.
 #[cfg(target_pointer_width = "64")]
 pub type NSUInteger = libc::c_ulong;
+
+pub type NSPoint = core_graphics::geometry::CGPoint;

--- a/src/foundation/mod.rs
+++ b/src/foundation/mod.rs
@@ -59,7 +59,7 @@ pub fn to_bool(result: BOOL) -> bool {
         #[cfg(not(target_arch = "aarch64"))]
         _ => {
             std::unreachable!();
-        },
+        }
     }
 }
 


### PR DESCRIPTION
I found that global NSEvent monitoring was not currently implemented, and on further investigation, local monitoring only used a single possible mask value.

This PR introduces a mechanism for handling bitmasks from enums (though I understand if you'd like me to remove it), unblocking the proper implementation of those methods. It also adds the missing event type enum values and a few NSEvent getters (though there are many more still to do).