### PR TITLE
Idiomatic NSArray iteration

### DIFF
--- a/src/pasteboard/mod.rs
+++ b/src/pasteboard/mod.rs
@@ -106,7 +106,7 @@ impl Pasteboard {
                 }));
             }
 
-            let urls = NSArray::retain(contents).map(|url| NSURL::retain(url)).into_iter().collect();
+            let urls = NSArray::retain(contents).iter().map(|url| NSURL::retain(url)).collect();
 
             Ok(urls)
         }


### PR DESCRIPTION
I went to pull some data out of a NSArray, and found that the array did not follow idiomatic iterator design. I was going to leave the original `map` method around, but found that it was referenced in only a few spots, and several of those spots wanted iterators anyway.

So this adds NSArray iteration, and removes the `.map(transform)` method, which was equivalent to `.iter().map(transform).collect()`