### PR TITLE
Fix `set_max_number_of_lines` causing crash on UIKit

### DIFF
--- a/src/text/label/mod.rs
+++ b/src/text/label/mod.rs
@@ -417,7 +417,10 @@ impl<T> Label<T> {
     /// Sets the maximum number of lines.
     pub fn set_max_number_of_lines(&self, num: NSInteger) {
         self.objc.with_mut(|obj| unsafe {
+            #[cfg(feature = "appkit")]
             let _: () = msg_send![obj, setMaximumNumberOfLines: num];
+            #[cfg(feature = "uikit")]
+            let _: () = msg_send![obj, setNumberOfLines: num];
         });
     }
 


### PR DESCRIPTION
Upon calling `set_max_number_of_lines` on a Label it crashes an iOS application at runtime.

**Crash output:**
```
2023-07-19 22:04:28.366 GUI-test[3974:3451982] -[RSTTextField setNNumberOfLines:]: unrecognized selector sent to instance 0x7f8099607040
2023-07-19 22:04:28.382 GUI-test[3974:3451982] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[RSTTextField setNNumberOfLines:]: unrecognized selector sent to instance 0x7f8099607040'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007ff80045478b __exceptionPreprocess + 242
	1   libobjc.A.dylib                     0x00007ff80004db73 objc_exception_throw + 48
	2   CoreFoundation                      0x00007ff8004638c4 +[NSObject(NSObject) instanceMethodSignatureForSelector:] + 0
	3   UIKitCore                           0x0000000111fa4822 -[UIResponder doesNotRecognizeSelector:] + 264
	4   CoreFoundation                      0x00007ff800458c66 ___forwarding___ + 1443
	5   CoreFoundation                      0x00007ff80045ae08 _CF_forwarding_prep_0 + 120
	6   GUI-test                            0x000000010811c360 _ZN64_$LT$$LP$A$C$$RP$$u20$as$u20$objc..message..MessageArguments$GT$6invoke17h129fc269c18c1262E + 96
	7   GUI-test                            0x00000001081189a1 _ZN4objc7message8platform15send_unverified17h09c653dbab16937eE + 129
	8   GUI-test                            0x0000000108129252 _ZN5cacao4text5label14Label$LT$T$GT$19set_number_of_lines28_$u7b$$u7b$closure$u7d$$u7d$17hae57f8573c8da855E + 322
	9   GUI-test                            0x0000000108120999 _ZN5cacao5utils10properties12ObjcProperty8with_mut17h2c482142ac93c6ddE + 185
	10  GUI-test                            0x0000000108129108 _ZN5cacao4text5label14Label$LT$T$GT$19set_number_of_lines17he0b8d2a1858e0153E + 40
	11  GUI-test                            0x00000001081193c5 _ZN89_$LT$GUI_test..gui..message..MessageView$u20$as$u20$cacao..view..traits..ViewDelegate$GT$8did_load17h39b10cf22e74e04fE + 597
	12  GUI-test                            0x000000010811db97 _ZN5cacao4view13View$LT$T$GT$4with17ha4fe70ac3993360cE + 1095
	13  GUI-test                            0x0000000108117358 _ZN61_$LT$GUI_test..RootView$u20$as$u20$core..default..Default$GT$7default17h85a8037eeeccbc8fE + 344
	14  GUI-test                            0x0000000108117e78 _ZN90_$LT$GUI_test..WindowScene$u20$as$u20$cacao..uikit..scene..traits..WindowSceneDelegate$GT$12will_connect17h74d17df88455fcc1E + 280
	15  GUI-test                            0x0000000108115500 _ZN5cacao5uikit5scene8delegate42scene_will_connect_to_session_with_options17hc9cc4f43b1a40e21E + 240
	16  UIKitCore                           0x00000001111760d8 +[UIScene _sceneForFBSScene:create:withSession:connectionOptions:] + 1394
	17  UIKitCore                           0x0000000111f6c055 -[UIApplication _connectUISceneFromFBSScene:transitionContext:] + 1319
	18  UIKitCore                           0x0000000111f6c62d -[UIApplication workspace:didCreateScene:withTransitionContext:completion:] + 562
	19  UIKitCore                           0x000000011190511f -[UIApplicationSceneClientAgent scene:didInitializeWithEvent:completion:] + 350
	20  FrontBoardServices                  0x00007ff8053f8bea -[FBSScene _callOutQueue_agent_didCreateWithTransitionContext:completion:] + 415
	21  FrontBoardServices                  0x00007ff805427c0e __92-[FBSWorkspaceScenesClient createSceneWithIdentity:parameters:transitionContext:completion:]_block_invoke.187 + 102
	22  FrontBoardServices                  0x00007ff805406bfc -[FBSWorkspace _calloutQueue_executeCalloutFromSource:withBlock:] + 209
	23  FrontBoardServices                  0x00007ff805427815 __92-[FBSWorkspaceScenesClient createSceneWithIdentity:parameters:transitionContext:completion:]_block_invoke + 344
	24  libdispatch.dylib                   0x00007ff80013d0d9 _dispatch_client_callout + 8
	25  libdispatch.dylib                   0x00007ff800140bf2 _dispatch_block_invoke_direct + 491
	26  FrontBoardServices                  0x00007ff80544e507 __FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__ + 30
	27  FrontBoardServices                  0x00007ff80544e3fd -[FBSSerialQueue _targetQueue_performNextIfPossible] + 174
	28  FrontBoardServices                  0x00007ff80544e52f -[FBSSerialQueue _performNextFromRunLoopSource] + 19
	29  CoreFoundation                      0x00007ff8003b2b8f __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
	30  CoreFoundation                      0x00007ff8003b2ad1 __CFRunLoopDoSource0 + 157
	31  CoreFoundation                      0x00007ff8003b232b __CFRunLoopDoSources0 + 311
	32  CoreFoundation                      0x00007ff8003ac9ba __CFRunLoopRun + 889
	33  CoreFoundation                      0x00007ff8003ac264 CFRunLoopRunSpecific + 560
	34  GraphicsServices                    0x00007ff809b4024e GSEventRunModal + 139
	35  UIKitCore                           0x0000000111f6a7bf -[UIApplication _run] + 994
	36  UIKitCore                           0x0000000111f6f5de UIApplicationMain + 123
	37  GUI-test                            0x0000000108123ee2 _ZN5cacao5uikit3app20App$LT$T$C$W$C$F$GT$3run17h27bea332ce2faa4dE + 1490
	38  GUI-test                            0x00000001081182bf _ZN8GUI_test4main17h012cb6c017e7704bE + 191
	39  GUI-test                            0x000000010811130e _ZN4core3ops8function6FnOnce9call_once17h931b15ade5b5320aE + 14
	40  GUI-test                            0x000000010811bf71 _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17h9a7f9bf6ab45ad7cE + 17
	41  GUI-test                            0x000000010811c294 _ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h60d1bcf655df097cE + 20
	42  GUI-test                            0x0000000108172efc _ZN3std2rt19lang_start_internal17hb74a432249acafb8E + 364
	43  GUI-test                            0x000000010811c267 _ZN3std2rt10lang_start17had703e3101c5c7f3E + 55
	44  GUI-test                            0x00000001081183e8 main + 24
	45  dyld                                0x00000001083d4384 start_sim + 10
	46  ???                                 0x000000010ac3441f 0x0 + 4475536415
)
libc++abi: terminating due to uncaught exception of type NSException
```

This seems to only happen on iOS. Replacing `let _: () = msg_send![obj, setMaximumNumberOfLines: num];` with `let _: () = msg_send![obj, setNumberOfLines: num];` seems to resolve the issue on iOS and causes a crash on macOS.
With this pull commit using the feature flags, the label works as expected on iOS and macOS.