### PR TITLE
feat: add set files util for pasteboard binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ libc = "0.2"
 os_info = "3.0.1"
 url = "2.1.1"
 uuid = { version = "1.1", features = ["v4"], optional = true }
+percent-encoding = "2.3.0"
 
 [dev-dependencies]
 eval = "0.4"

--- a/src/pasteboard/mod.rs
+++ b/src/pasteboard/mod.rs
@@ -159,6 +159,5 @@ mod pasteboard_test {
         let urls = pb.get_file_urls().unwrap();
         let got: Vec<PathBuf> = urls.into_iter().map(|u| u.pathbuf()).collect();
         assert_eq!(got, paths);
-        println!("successful!");
     }
 }

--- a/src/pasteboard/mod.rs
+++ b/src/pasteboard/mod.rs
@@ -111,4 +111,31 @@ impl Pasteboard {
             Ok(urls)
         }
     }
+
+    /// Write a list of path to the pasteboard
+    pub fn set_files(&self, paths: &[&Path]) -> Result<(), Box<dyn std::error::Error>> {
+        unsafe {
+            let urls: Vec<NSURL> = paths
+                .iter()
+                .map(|p| {
+                    let url = format!("file://{}", p.display());
+                    NSURL::with_str(&url)
+                })
+                .collect();
+            let url_arr = NSArray::new(&urls);
+
+            let _: id = msg_send![&*self.0, clearContents];
+            let succ: bool = msg_send![&*self.0, writeObjects: &*url_arr];
+
+            if succ {
+                Ok(())
+            } else {
+                return Err(Box::new(Error {
+                    code: 666,
+                    domain: "com.cacao-rs.pasteboard".to_string(),
+                    description: "Pasteboard server set urls fail.".to_string()
+                }));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Hello, I'd like to implement file pasting on OSX, but sadly I know nothing about Swift and Obj-C. Thankfully, I found your project, and I'd like to add a patch to satisfy my need.

This PR merely adds a `set_files` method to `Pasteboard`. And it's expected to convert paths you put in to NSURLs and write into the clipboard.

~~Note that this PR is currently UNTESTED.~~