### PR TITLE
add support for named fonts

### DIFF
--- a/examples/safe_area.rs
+++ b/examples/safe_area.rs
@@ -8,7 +8,7 @@ use cacao::view::{View, ViewDelegate};
 
 struct BasicApp {
     window: Window,
-    content_view: View<ContentView>
+    content_view: View<ContentView>,
 }
 
 impl AppDelegate for BasicApp {
@@ -29,20 +29,42 @@ impl AppDelegate for BasicApp {
 #[derive(Default)]
 struct ContentView {
     content: View,
-    label: Label
+    label: Label,
+    label2: Label,
+    label3: Label,
 }
 
 impl ViewDelegate for ContentView {
     const NAME: &'static str = "SafeAreaView";
 
     fn did_load(&mut self, view: View) {
+        let color_black = cacao::color::Color::rgb(255, 255, 255);
+
         let font = Font::system(30.);
         self.label.set_font(&font);
         self.label.set_text("Hello World");
-        self.label.set_text_color(cacao::color::Color::rgb(255, 255, 255));
+        self.label.set_text_color(&color_black);
+
+        let times_new_roman = Font::with_name("Times New Roman", 30.);
+        self.label2.set_font(&times_new_roman);
+        self.label2.set_text("Hello World (In 'Times New Roman')");
+        self.label2.set_text_color(&color_black);
+
+        let helvetica = Font::with_name("Helvetica", 30.);
+        self.label3.set_font(&helvetica);
+        self.label3.set_text("Hello World (In 'Helvetica')");
+        self.label3.set_text_color(&color_black);
 
         self.content.add_subview(&self.label);
+        self.content.add_subview(&self.label2);
+        self.content.add_subview(&self.label3);
         view.add_subview(&self.content);
+
+        // layouts for labels
+        cacao::layout::LayoutConstraint::activate(&[
+            self.label2.top.constraint_equal_to(&self.label.bottom).offset(2.),
+            self.label3.top.constraint_equal_to(&self.label2.bottom).offset(2.),
+        ]);
 
         // Add layout constraints to be 100% excluding the safe area
         // Do last because it will crash because the view needs to be inside the hierarchy
@@ -50,15 +72,18 @@ impl ViewDelegate for ContentView {
             self.content.top.constraint_equal_to(&view.safe_layout_guide.top),
             self.content.leading.constraint_equal_to(&view.safe_layout_guide.leading),
             self.content.trailing.constraint_equal_to(&view.safe_layout_guide.trailing),
-            self.content.bottom.constraint_equal_to(&view.safe_layout_guide.bottom)
+            self.content.bottom.constraint_equal_to(&view.safe_layout_guide.bottom),
         ])
     }
 }
 
 fn main() {
-    App::new("com.test.window", BasicApp {
-        window: Window::default(),
-        content_view: View::with(ContentView::default())
-    })
+    App::new(
+        "com.test.window",
+        BasicApp {
+            window: Window::default(),
+            content_view: View::with(ContentView::default()),
+        },
+    )
     .run();
 }

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -54,6 +54,12 @@ impl Font {
         Font(unsafe { msg_send_id![Self::class(), boldSystemFontOfSize: size] })
     }
 
+    /// Creates and returns a font for the specified font name and size.
+    pub fn with_name(name: &str, size: f64) -> Self {
+        let font_name = NSString::new(name);
+        Font(unsafe { msg_send_id![Self::class(), fontWithName: &*font_name, size: size] })
+    }
+
     /// Creates and returns a monospace system font at the specified size and weight
     ///
     /// # Support
@@ -96,4 +102,5 @@ fn font_test() {
     let default_font = Font::default();
     let system_font = Font::system(100.0);
     let bold_system_font = Font::bold_system(100.0);
+    let named_font = Font::with_name("Times New Roman", 100.0);
 }


### PR DESCRIPTION
While exploring this crate for a project, I noticed there was no support for custom fonts (only system fonts.)

After reading through the AppKit docs and the source code a bit, it was pretty straightforward to add. I've also updated the `safe_area` example which just prints "Hello Word" in two additional custom fonts; wasn't sure a more relevant example to put this.

(NOTE: the trailing commas were added by my editor's formatter, if we really want them removed it won't be a big deal)

![Screenshot 2023-11-10 at 12 54 03 AM](https://github.com/ryanmcgrath/cacao/assets/49159969/5c2aa9ed-1ce3-4835-b21b-dd35621d1016)
