### PR TITLE
Add characters_ignoring_modifiers to get chars ignoring modifiers on keyup/down events

### DIFF
--- a/src/appkit/event/mod.rs
+++ b/src/appkit/event/mod.rs
@@ -85,6 +85,16 @@ impl Event {
         characters.to_string()
     }
 
+    /// The characters associated with a key-up or key-down event as if no modifier key (except for Shift) applies.
+    pub fn characters_no_mods(&self) -> String {
+        // @TODO: Check here if key event, invalid otherwise.
+        // @TODO: Figure out if we can just return &str here, since the Objective-C side
+        // should... make it work, I think.
+        let characters = NSString::retain(unsafe { msg_send![&*self.0, charactersIgnoringModifiers] });
+
+        characters.to_string()
+    }
+
     /// An integer bit field that indicates the pressed modifier keys
     pub fn modifier_flags(&self) -> EventModifierBitFlag {
         let flags: NSUInteger = unsafe { msg_send![&*self.0, modifierFlags] };


### PR DESCRIPTION
Copy&pasted the existing `pub fn characters(&self)` with a different constant

https://developer.apple.com/documentation/appkit/nsevent/1524605-charactersignoringmodifiers


(btw, is 
- `characters_ignoring_modifiers` verbose really better to read vs
- `chars_no_mods` (the verbosity level of `constraint_greater_than_or_equal_to` makes it worse imo)