### PR TITLE
Add missing keys to EventModifierFlag

### DIFF
--- a/src/appkit/event/mod.rs
+++ b/src/appkit/event/mod.rs
@@ -180,6 +180,7 @@ use crate::foundation::NSUInteger;
 #[derive(Clone, Copy, Debug)]
 pub enum EventModifierFlag {
     CapsLock,
+    Shift,
     Control,
     Option,
     Command,
@@ -190,6 +191,7 @@ impl From<EventModifierFlag> for NSUInteger {
     fn from(flag: EventModifierFlag) -> NSUInteger {
         match flag {
             EventModifierFlag::CapsLock => 1 << 16,
+            EventModifierFlag::Shift => 1 << 17,
             EventModifierFlag::Control => 1 << 18,
             EventModifierFlag::Option => 1 << 19,
             EventModifierFlag::Command => 1 << 20,
@@ -202,6 +204,7 @@ impl From<&EventModifierFlag> for NSUInteger {
     fn from(flag: &EventModifierFlag) -> NSUInteger {
         match flag {
             EventModifierFlag::CapsLock => 1 << 16,
+            EventModifierFlag::Shift => 1 << 17,
             EventModifierFlag::Control => 1 << 18,
             EventModifierFlag::Option => 1 << 19,
             EventModifierFlag::Command => 1 << 20,

--- a/src/events.rs
+++ b/src/events.rs
@@ -9,6 +9,9 @@ pub enum EventModifierFlag {
     /// CapsLock (or shift... oddly named...) is held.
     CapsLock,
 
+    /// Shift is held.
+    Shift,
+
     /// Control is held.
     Control,
 
@@ -26,6 +29,7 @@ impl From<EventModifierFlag> for NSUInteger {
     fn from(flag: EventModifierFlag) -> NSUInteger {
         match flag {
             EventModifierFlag::CapsLock => 1 << 16,
+            EventModifierFlag::Shift => 1 << 17,
             EventModifierFlag::Control => 1 << 18,
             EventModifierFlag::Option => 1 << 19,
             EventModifierFlag::Command => 1 << 20,
@@ -38,6 +42,7 @@ impl From<&EventModifierFlag> for NSUInteger {
     fn from(flag: &EventModifierFlag) -> NSUInteger {
         match flag {
             EventModifierFlag::CapsLock => 1 << 16,
+            EventModifierFlag::Shift => 1 << 17,
             EventModifierFlag::Control => 1 << 18,
             EventModifierFlag::Option => 1 << 19,
             EventModifierFlag::Command => 1 << 20,


### PR DESCRIPTION
Completes it with shift, function, help, numpad keys

https://developer.apple.com/documentation/appkit/nseventmodifierflags?language=objc