### PR TITLE
Add supoprt for getting key_code on key events

### DIFF
--- a/src/appkit/event/mod.rs
+++ b/src/appkit/event/mod.rs
@@ -6,7 +6,7 @@ use objc::runtime::Object;
 use objc::{class, msg_send, msg_send_id, sel};
 
 use crate::events::EventType;
-use crate::foundation::{id, nil, NSInteger, NSPoint, NSString};
+use crate::foundation::{id, nil, NSInteger, NSPoint, NSString, NSUInt16};
 
 mod test;
 
@@ -95,6 +95,14 @@ impl Event {
     /// A raw integer bit field that indicates the pressed modifier keys
     pub fn modifier_flags_raw(&self) -> NSUInteger {
         unsafe { msg_send![&*self.0, modifierFlags] }
+    }
+
+    /// The virtual code for the key associated with the event
+    pub fn key_code(&self) -> NSUInt16 {
+        // @TODO: Check here if key event, invalid otherwise.
+        // @TODO: Figure out if we can just return &str here, since the Objective-C side
+        // should... make it work, I think.
+        unsafe { msg_send![&*self.0, keyCode] }
     }
 
     /// The indices of the currently pressed mouse buttons.

--- a/src/appkit/event/test.rs
+++ b/src/appkit/event/test.rs
@@ -1,21 +1,21 @@
-#[cfg(test)]
+#[cfg(test)] #[rustfmt::skip]
 mod event_test {
     use crate::appkit::EventModifierBitFlag;
     #[test]
     fn test_event_modifier_bit_flag_display() {
-        assert_eq!("‹⇧"                , format!("{}",EventModifierBitFlag::LeftShift));
-        assert_eq!("‹⇧›"               , format!("{}",EventModifierBitFlag::Shift));
-        assert_eq!("⇧›"                , format!("{}",EventModifierBitFlag::RightShift));
-        assert_eq!("‹⇧‹⌃‹⌥‹⌘"        , format!("{}",EventModifierBitFlag::LeftModi));
-        assert_eq!("⇧›⌃›⌥›⌘›"        , format!("{}",EventModifierBitFlag::RightModi));
-        assert_eq!("‹⇧›‹⌃›‹⌥›‹⌘›"    , format!("{}",EventModifierBitFlag::LRModi));
-        assert_eq!("🌐"                , format!("{:#}",EventModifierBitFlag::Function)); // when it's a modifier key
-        assert_eq!("ƒ"                , format!("{}",EventModifierBitFlag::Function));
-        assert_eq!("⇭"                 , format!("{:#}",EventModifierBitFlag::Numpad)); // when it's a modifier key
-        assert_eq!("🔢"                 , format!("{}",EventModifierBitFlag::Numpad));
-        assert_eq!("ℹ"                 , format!("{}",EventModifierBitFlag::Help));
-        assert_eq!("!🖮"                , format!("{}",EventModifierBitFlag::DeviceIndependentFlagsMask));
+        assert_eq!("‹⇧"           ,format!("{}"  ,EventModifierBitFlag::LeftShift  ));
+        assert_eq!("‹⇧›"          ,format!("{}"  ,EventModifierBitFlag::Shift      ));
+        assert_eq!("⇧›"           ,format!("{}"  ,EventModifierBitFlag::RightShift ));
+        assert_eq!("‹⇧‹⌃‹⌥‹⌘"    ,format!("{}"  ,EventModifierBitFlag::LeftModi   ));
+        assert_eq!("⇧›⌃›⌥›⌘›"    ,format!("{}"  ,EventModifierBitFlag::RightModi  ));
+        assert_eq!("‹⇧›‹⌃›‹⌥›‹⌘›",format!("{}"  ,EventModifierBitFlag::LRModi     ));
+        assert_eq!("🌐"           ,format!("{:#}",EventModifierBitFlag::Function   )); // when it's a modifier key
+        assert_eq!("ƒ"            ,format!("{}"  ,EventModifierBitFlag::Function   ));
+        assert_eq!("⇭"            ,format!("{:#}",EventModifierBitFlag::Numpad     )); // when it's a modifier key
+        assert_eq!("🔢"           ,format!("{}"  ,EventModifierBitFlag::Numpad     ));
+        assert_eq!("ℹ"           ,format!("{}"  ,EventModifierBitFlag::Help       ));
+        assert_eq!("!🖮"           ,format!("{}"  ,EventModifierBitFlag::DeviceIndependentFlagsMask));
         // Shift ignored, only flagmask remains
-        assert_eq!("!🖮"                , format!("{}",EventModifierBitFlag::DeviceIndependentFlagsMask | EventModifierBitFlag::RightShift));
+        assert_eq!("!🖮"           ,format!("{}"  ,EventModifierBitFlag::DeviceIndependentFlagsMask | EventModifierBitFlag::RightShift));
     }
 }

--- a/src/foundation/mod.rs
+++ b/src/foundation/mod.rs
@@ -87,4 +87,6 @@ pub type NSInteger = libc::c_long;
 #[cfg(target_pointer_width = "64")]
 pub type NSUInteger = libc::c_ulong;
 
+pub type NSUInt16 = libc::c_ushort;
+
 pub type NSPoint = core_graphics::geometry::CGPoint;


### PR DESCRIPTION
to get key's virtual code on keydown/up events and be able to tell keys apart in input handling

https://developer.apple.com/documentation/appkit/nsevent/1534513-keycode?language=objc